### PR TITLE
added "clear_registered_nodes" method

### DIFF
--- a/NodeGraphQt/base/vendor.py
+++ b/NodeGraphQt/base/vendor.py
@@ -75,6 +75,13 @@ class _NodeVendor(object):
                 raise AssertionError(
                     'Node Alias: {} already taken!'.format(alias))
             self._aliases[alias] = node_type
-
-
+            
+     def clear_registered_nodes(self):
+        """
+        clear out registered nodes, to prevent conflicts on reset
+        """
+        self._nodes.clear()
+        self._names.clear()
+        self._aliases.clear()
+        
 NodeVendor = _NodeVendor()


### PR DESCRIPTION
Prototyping a plugin node in parallel with NodeGraphQT can cause an "already registered" error if the host application is not closed in between. Calling new method will prevent this.