### PR TITLE
Fix vendor.py extra space

### DIFF
--- a/NodeGraphQt/base/vendor.py
+++ b/NodeGraphQt/base/vendor.py
@@ -76,12 +76,12 @@ class _NodeVendor(object):
                     'Node Alias: {} already taken!'.format(alias))
             self._aliases[alias] = node_type
             
-     def clear_registered_nodes(self):
-        """
-        clear out registered nodes, to prevent conflicts on reset
-        """
-        self._nodes.clear()
-        self._names.clear()
-        self._aliases.clear()
-        
+    def clear_registered_nodes(self):
+       """
+       clear out registered nodes, to prevent conflicts on reset
+       """
+       self._nodes.clear()
+       self._names.clear()
+       self._aliases.clear()
+       
 NodeVendor = _NodeVendor()


### PR DESCRIPTION
I found small bug in your awesome library. I found extra space in clear_registered_nodes method.