### PR TITLE
added node_selected signal

### DIFF
--- a/NodeGraphQt/base/graph.py
+++ b/NodeGraphQt/base/graph.py
@@ -19,6 +19,8 @@ from NodeGraphQt.widgets.viewer import NodeViewer
 
 
 class NodeGraph(QtCore.QObject):
+  
+    node_selected = QtCore.Signal(list)
 
     def __init__(self, parent=None):
         super(NodeGraph, self).__init__(parent)
@@ -32,6 +34,7 @@ class NodeGraph(QtCore.QObject):
         self._viewer.moved_nodes.connect(self._on_nodes_moved)
         self._viewer.search_triggered.connect(self._on_search_triggered)
         self._viewer.connection_changed.connect(self._on_connection_changed)
+        self._viewer.node_selected.connect(self._on_node_selected)
 
     def _init_actions(self):
         # setup tab search shortcut.
@@ -60,6 +63,14 @@ class NodeGraph(QtCore.QObject):
             node = self._model.nodes[node_view.id]
             self._undo_stack.push(NodeMovedCmd(node, node.pos(), prev_pos))
         self._undo_stack.endMacro()
+
+    def _on_nodes_moved(self, node_data):
+        """
+        called when a node in the viewer is selected on left click.
+
+        """
+        nodes = self.selected_nodes()
+        self.node_selected.emit(nodes)
 
     def _on_search_triggered(self, node_type, pos):
         """

--- a/NodeGraphQt/widgets/viewer.py
+++ b/NodeGraphQt/widgets/viewer.py
@@ -66,6 +66,7 @@ class NodeViewer(QtWidgets.QGraphicsView):
     moved_nodes = QtCore.Signal(dict)
     search_triggered = QtCore.Signal(str, tuple)
     connection_changed = QtCore.Signal(list, list)
+    node_selected = QtCore.Signal()
 
     def __init__(self, parent=None):
         super(NodeViewer, self).__init__(parent)
@@ -207,6 +208,11 @@ class NodeViewer(QtWidgets.QGraphicsView):
         if not shift_modifier:
             super(NodeViewer, self).mousePressEvent(event)
 
+        if event.button() == QtCore.Qt.LeftButton:
+            # emit specific node selected signal
+            if self.selected_nodes():
+                self.node_selected.emit()
+            
     def mouseReleaseEvent(self, event):
         if event.button() == QtCore.Qt.LeftButton:
             self.LMB_state = False


### PR DESCRIPTION
This probably isn't the cleanest implementation (I still suck at Qt), but it's a simple way to know what nodes are selected when. I'm using it in my own hybrid of nodeGraphQt to update the node attributes/settings pane immediately