### PR TITLE
added modify_context_menu methods

### DIFF
--- a/NodeGraphQt/base/graph.py
+++ b/NodeGraphQt/base/graph.py
@@ -29,6 +29,7 @@ class NodeGraph(QtCore.QObject):
         self._undo_stack = QUndoStack(self)
         self._init_actions()
         self._wire_signals()
+        self.patch_context_menu()
 
     def _wire_signals(self):
         self._viewer.moved_nodes.connect(self._on_nodes_moved)
@@ -191,7 +192,23 @@ class NodeGraph(QtCore.QObject):
             ContextMenu: node graph context menu object instance.
         """
         return self._viewer.context_menu()
+      
+    @staticmethod
+	  def modify_context_menu(viewer):
+        """
+        Viewer's method will be replaced with this one, 
+        called on every right-click
+        """
+        pass
 
+  	def patch_context_menu(self):
+        """
+        Patches viewer's modify_context_menu method to that of graph
+        """
+        self._viewer.modify_context_menu = types.MethodType(
+            self.modify_context_menu, self._viewer)
+
+  
     def acyclic(self):
         """
         Returns true if the current node graph is acyclic.

--- a/NodeGraphQt/widgets/viewer.py
+++ b/NodeGraphQt/widgets/viewer.py
@@ -163,6 +163,7 @@ class NodeViewer(QtWidgets.QGraphicsView):
 
     def contextMenuEvent(self, event):
         self.RMB_state = False
+        self.modify_context_menu()
         self._context_menu.exec_(event.globalPos())
 
     def mousePressEvent(self, event):
@@ -507,6 +508,14 @@ class NodeViewer(QtWidgets.QGraphicsView):
         else:
             self._search_widget.setVisible(state)
             self.clearFocus()
+
+   	def modify_context_menu(self):
+		"""to be overridden at a higher level, intended to allow context
+		menu to show different items based on
+		well
+		context
+		"""
+		pass
 
     def context_menu(self):
         return ContextMenu(self, self._context_menu)


### PR DESCRIPTION
added capability to access and modify the context menu from the graph widget (and inheritors), allowing the menu to change according to the state of the scene when called