### PR TITLE
Fix refactoring typo, refactor self.graph.model to self.model in redo()

### DIFF
--- a/NodeGraphQt/base/commands.py
+++ b/NodeGraphQt/base/commands.py
@@ -118,7 +118,7 @@ class NodeAddedCmd(QtWidgets.QUndoCommand):
         self.node.view.delete()
 
     def redo(self):
-        self.graph.model.nodes[self.node.id] = self.node
+        self.model.nodes[self.node.id] = self.node
         self.viewer.add_node(self.node.view, self.pos)
 
 


### PR DESCRIPTION
The `self.graph` variable does not exist as only `self.model = graph.model` is stored on the object. As such this fix is needed to have the code evaluate correctly. Without this fix the graph could not add any nodes whatsoever.