### PR TITLE
fix: Remove preemptive pipe deletion

### DIFF
--- a/NodeGraphQt/widgets/viewer.py
+++ b/NodeGraphQt/widgets/viewer.py
@@ -391,7 +391,6 @@ class NodeViewer(QtWidgets.QGraphicsView):
             self._detached_port = getattr(pipe, attr[from_port.port_type])
             self.start_live_connection(from_port)
             self._live_pipe.draw_path(self._start_port, None, pos)
-            pipe.delete()
 
     def sceneMouseReleaseEvent(self, event):
         """


### PR DESCRIPTION
Leave the original pipe in view while the user is making
a new connection.

Remove pipe after connection_changed signals is fired rather
than immediately.

Closes #124