### PR TITLE
Add ability to load from dictionary.

### DIFF
--- a/NodeGraphQt/base/graph.py
+++ b/NodeGraphQt/base/graph.py
@@ -811,6 +811,17 @@ class NodeGraph(QtCore.QObject):
         """
         return self._serialize(self.all_nodes())
 
+    def deserialize_session(self, layout_data):
+        """
+        Load node graph session from a dictionary object.
+
+        Args:
+            layout_data (dict): dictionary object containing a node session.
+        """
+        self.clear_session()
+        self._deserialize(layout_data)
+        self._undo_stack.clear()
+
     def save_session(self, file_path):
         """
         Saves the current node graph session layout to a `JSON` formatted file.


### PR DESCRIPTION
Currently, we can only pass a path in to load a session unless we use the private _deserialize function.  I added the ability to load a session straight from a dictionary object which is useful if the graph is part of a larger json configuration file.