### PR TITLE
Set NodeFactory attributes scope to instance to allow several node graphs

### DIFF
--- a/NodeGraphQt/base/factory.py
+++ b/NodeGraphQt/base/factory.py
@@ -8,9 +8,10 @@ class NodeFactory(object):
     Node factory that stores all the node types.
     """
 
-    __aliases = {}
-    __names = {}
-    __nodes = {}
+    def __init__(self):
+        self.__aliases = {}
+        self.__names = {}
+        self.__nodes = {}
 
     @property
     def names(self):


### PR DESCRIPTION
Currently, NodeFactory attributes are declared as class attributes but are used as instance ones. This is not a problem for an application having only one NodeGraph. But as soon as you need more than one NodeGraph, this becomes an issue as nodes are registered for all graphs, which may not be the desired behavior.

The simplest fix is to move NodeFactory attributes scope from class to instance.