### PR TITLE
Fix `setCurrentIndex` AttributeError

### DIFF
--- a/example_auto_nodes/node_base/module_node.py
+++ b/example_auto_nodes/node_base/module_node.py
@@ -54,8 +54,9 @@ class ModuleNode(AutoNode):
         self.add_output('output')
         self.create_property('output', None)
 
-        self.view.widgets['funcs'].widget.setCurrentIndex(0)
-        self.add_function(None, self.view.widgets['funcs'].widget.currentText())
+        self.view.widgets['funcs'].get_custom_widget().setCurrentIndex(0)
+        self.add_function(
+            None, self.view.widgets['funcs'].get_custom_widget().currentText())
 
     def is_function(self, obj):
         if inspect.isfunction(self.func) or inspect.isbuiltin(self.func):

--- a/example_nodes/math_node.py
+++ b/example_nodes/math_node.py
@@ -32,7 +32,7 @@ class MathFunctionsNode(BaseNode):
         self.create_property('output', None)
         self.trigger_type = 'no_inPorts'
 
-        self.view.widgets['funcs'].widget.setCurrentIndex(2)
+        self.view.widgets['funcs'].get_custom_widget().setCurrentIndex(2)
 
     def addFunction(self, prop, func):
         """


### PR DESCRIPTION
## Descriptin of problem
When Math node is added in AttributeError is raised. `AttributeError: 'builtin_function_or_method' object has no attribute 'setCurrentIndex'`

## How it happens
- running `example_math_nodes.py`
- running `example_auto_nodes.py`
