### PR TITLE
Node Error State

### DIFF
--- a/NodeGraphQt/base/model.py
+++ b/NodeGraphQt/base/model.py
@@ -76,6 +76,7 @@ class NodeModel(object):
         self.inputs = {}
         self.outputs = {}
         self._custom_prop = {}
+        self.error = None
 
         # node graph model set at node added time.
         self._graph_model = None
@@ -101,6 +102,7 @@ class NodeModel(object):
             'pos': NODE_PROP,
             'inputs': NODE_PROP,
             'outputs': NODE_PROP,
+            'error': NODE_PROP,
         }
 
     def __repr__(self):

--- a/NodeGraphQt/qgraphics/node_abstract.py
+++ b/NodeGraphQt/qgraphics/node_abstract.py
@@ -138,6 +138,14 @@ class AbstractNodeItem(QtWidgets.QGraphicsItem):
         self._properties['disabled'] = state
 
     @property
+    def error(self):
+        return self._properties['error']
+
+    @error.setter
+    def error(self, msg=None):
+        self._properties['error'] = msg
+
+    @property
     def selected(self):
         if self._properties['selected'] != self.isSelected():
             self._properties['selected'] = self.isSelected()

--- a/NodeGraphQt/qgraphics/node_abstract.py
+++ b/NodeGraphQt/qgraphics/node_abstract.py
@@ -24,6 +24,7 @@ class AbstractNodeItem(QtWidgets.QGraphicsItem):
             'selected': False,
             'disabled': False,
             'visible': False,
+            'error': None,
         }
         self._width = NODE_WIDTH
         self._height = NODE_HEIGHT

--- a/NodeGraphQt/qgraphics/node_base.py
+++ b/NodeGraphQt/qgraphics/node_base.py
@@ -36,6 +36,7 @@ class NodeItem(AbstractNodeItem):
         self._icon_item.setTransformationMode(QtCore.Qt.SmoothTransformation)
         self._text_item = NodeTextItem(self.name, self)
         self._x_item = XDisabledItem(self, 'DISABLED')
+        self._x_error = XDisabledItem(self, 'ERROR')
         self._input_items = OrderedDict()
         self._output_items = OrderedDict()
         self._widgets = OrderedDict()
@@ -187,6 +188,20 @@ class NodeItem(AbstractNodeItem):
         if state:
             tooltip += ' <font color="red"><b>(DISABLED)</b></font>'
         tooltip += '<br/>{}<br/>'.format(self.type_)
+        self.setToolTip(tooltip)
+
+    def _tooltip_error(self, msg=None):
+        """
+        Updates the node tooltip for errors.
+
+        Args:
+            msg (str, optional): the error message.
+        """
+        tooltip = f'<b>{self.name}</b>'
+        state = msg is not None
+        if state:
+            tooltip += f' <font color="red"><b>{msg}</b></font>'
+        tooltip += f'<br/>{self.type_}<br/>'
         self.setToolTip(tooltip)
 
     def _set_base_size(self, add_w=0.0, add_h=0.0):
@@ -535,6 +550,15 @@ class NodeItem(AbstractNodeItem):
             w.widget().setDisabled(state)
         self._tooltip_disable(state)
         self._x_item.setVisible(state)
+
+    @AbstractNodeItem.error.setter
+    def error(self, msg=None):
+        AbstractNodeItem.error.fset(self, msg)
+        state = msg is not None
+        for n, w in self._widgets.items():
+            w.widget().setDisabled(state)
+        self._tooltip_error(msg)
+        self._x_error.setVisible(state)
 
     @AbstractNodeItem.selected.setter
     def selected(self, selected=False):


### PR DESCRIPTION
This allows a node to display an error state that looks like the disabled state, but with error text and the message in the tooltip. Here's an example of how to use it:

```python
class ShowError(BaseNode):
    __identifier__ = "Viewers"
    NODE_NAME = "Display Error When Connected"

    def __init__(self):
        super().__init__()
        self.inPort = self.add_input('data')
        self.add_text_input('data', 'Data Viewer', tab='widgets')

    def on_input_connected(self, to_port, from_port):
        """Override node callback method"""
        self.run()

    def on_input_disconnected(self, to_port, from_port):
        """Override node callback method"""
        self.view.error = None
        self.set_property('data', None)

    def run(self):
        self.view.error = "This is the error message."
```

Any connection to this node will put it into error. Disconnect it and it will clear.