### PR TITLE
Follow reuse/spdx standards + license docs under CC-By-4.0

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -1,0 +1,22 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: NodeGraphQt
+Upstream-Contact: Johnny Chan
+Source: https://github.com/jchanvfx/NodeGraphQt
+
+# Sample paragraph, commented out:
+#
+# Files: src/*
+# Copyright: $YEAR $NAME <$CONTACT>
+# License: ...
+
+Files: MANIFEST.in
+Copyright: 2021 Johnny Chan
+License: MIT
+
+Files: *.node *.nodes
+Copyright: 2021 Johnny Chan
+License: MIT
+
+Files: docs/_images/*
+Copyright: 2021 Johnny Chan
+License: CC-BY-4.0

--- a/LICENSES/CC-BY-4.0.txt
+++ b/LICENSES/CC-BY-4.0.txt
@@ -1,0 +1,156 @@
+Creative Commons Attribution 4.0 International
+
+ Creative Commons Corporation (“Creative Commons”) is not a law firm and does not provide legal services or legal advice. Distribution of Creative Commons public licenses does not create a lawyer-client or other relationship. Creative Commons makes its licenses and related information available on an “as-is” basis. Creative Commons gives no warranties regarding its licenses, any material licensed under their terms and conditions, or any related information. Creative Commons disclaims all liability for damages resulting from their use to the fullest extent possible.
+
+Using Creative Commons Public Licenses
+
+Creative Commons public licenses provide a standard set of terms and conditions that creators and other rights holders may use to share original works of authorship and other material subject to copyright and certain other rights specified in the public license below. The following considerations are for informational purposes only, are not exhaustive, and do not form part of our licenses.
+
+Considerations for licensors: Our public licenses are intended for use by those authorized to give the public permission to use material in ways otherwise restricted by copyright and certain other rights. Our licenses are irrevocable. Licensors should read and understand the terms and conditions of the license they choose before applying it. Licensors should also secure all rights necessary before applying our licenses so that the public can reuse the material as expected. Licensors should clearly mark any material not subject to the license. This includes other CC-licensed material, or material used under an exception or limitation to copyright. More considerations for licensors.
+
+Considerations for the public: By using one of our public licenses, a licensor grants the public permission to use the licensed material under specified terms and conditions. If the licensor’s permission is not necessary for any reason–for example, because of any applicable exception or limitation to copyright–then that use is not regulated by the license. Our licenses grant only permissions under copyright and certain other rights that a licensor has authority to grant. Use of the licensed material may still be restricted for other reasons, including because others have copyright or other rights in the material. A licensor may make special requests, such as asking that all changes be marked or described. Although not required by our licenses, you are encouraged to respect those requests where reasonable. More considerations for the public.
+
+Creative Commons Attribution 4.0 International Public License
+
+By exercising the Licensed Rights (defined below), You accept and agree to be bound by the terms and conditions of this Creative Commons Attribution 4.0 International Public License ("Public License"). To the extent this Public License may be interpreted as a contract, You are granted the Licensed Rights in consideration of Your acceptance of these terms and conditions, and the Licensor grants You such rights in consideration of benefits the Licensor receives from making the Licensed Material available under these terms and conditions.
+
+Section 1 – Definitions.
+
+     a.	Adapted Material means material subject to Copyright and Similar Rights that is derived from or based upon the Licensed Material and in which the Licensed Material is translated, altered, arranged, transformed, or otherwise modified in a manner requiring permission under the Copyright and Similar Rights held by the Licensor. For purposes of this Public License, where the Licensed Material is a musical work, performance, or sound recording, Adapted Material is always produced where the Licensed Material is synched in timed relation with a moving image.
+
+     b.	Adapter's License means the license You apply to Your Copyright and Similar Rights in Your contributions to Adapted Material in accordance with the terms and conditions of this Public License.
+
+     c.	Copyright and Similar Rights means copyright and/or similar rights closely related to copyright including, without limitation, performance, broadcast, sound recording, and Sui Generis Database Rights, without regard to how the rights are labeled or categorized. For purposes of this Public License, the rights specified in Section 2(b)(1)-(2) are not Copyright and Similar Rights.
+
+     d.	Effective Technological Measures means those measures that, in the absence of proper authority, may not be circumvented under laws fulfilling obligations under Article 11 of the WIPO Copyright Treaty adopted on December 20, 1996, and/or similar international agreements.
+
+     e.	Exceptions and Limitations means fair use, fair dealing, and/or any other exception or limitation to Copyright and Similar Rights that applies to Your use of the Licensed Material.
+
+     f.	Licensed Material means the artistic or literary work, database, or other material to which the Licensor applied this Public License.
+
+     g.	Licensed Rights means the rights granted to You subject to the terms and conditions of this Public License, which are limited to all Copyright and Similar Rights that apply to Your use of the Licensed Material and that the Licensor has authority to license.
+
+     h.	Licensor means the individual(s) or entity(ies) granting rights under this Public License.
+
+     i.	Share means to provide material to the public by any means or process that requires permission under the Licensed Rights, such as reproduction, public display, public performance, distribution, dissemination, communication, or importation, and to make material available to the public including in ways that members of the public may access the material from a place and at a time individually chosen by them.
+
+     j.	Sui Generis Database Rights means rights other than copyright resulting from Directive 96/9/EC of the European Parliament and of the Council of 11 March 1996 on the legal protection of databases, as amended and/or succeeded, as well as other essentially equivalent rights anywhere in the world.
+
+     k.	You means the individual or entity exercising the Licensed Rights under this Public License. Your has a corresponding meaning.
+
+Section 2 – Scope.
+
+     a.	License grant.
+
+          1. Subject to the terms and conditions of this Public License, the Licensor hereby grants You a worldwide, royalty-free, non-sublicensable, non-exclusive, irrevocable license to exercise the Licensed Rights in the Licensed Material to:
+
+               A. reproduce and Share the Licensed Material, in whole or in part; and
+
+               B. produce, reproduce, and Share Adapted Material.
+
+          2. Exceptions and Limitations. For the avoidance of doubt, where Exceptions and Limitations apply to Your use, this Public License does not apply, and You do not need to comply with its terms and conditions.
+
+          3. Term. The term of this Public License is specified in Section 6(a).
+
+          4. Media and formats; technical modifications allowed. The Licensor authorizes You to exercise the Licensed Rights in all media and formats whether now known or hereafter created, and to make technical modifications necessary to do so. The Licensor waives and/or agrees not to assert any right or authority to forbid You from making technical modifications necessary to exercise the Licensed Rights, including technical modifications necessary to circumvent Effective Technological Measures. For purposes of this Public License, simply making modifications authorized by this Section 2(a)(4) never produces Adapted Material.
+
+          5. Downstream recipients.
+
+               A. Offer from the Licensor – Licensed Material. Every recipient of the Licensed Material automatically receives an offer from the Licensor to exercise the Licensed Rights under the terms and conditions of this Public License.
+
+               B. No downstream restrictions. You may not offer or impose any additional or different terms or conditions on, or apply any Effective Technological Measures to, the Licensed Material if doing so restricts exercise of the Licensed Rights by any recipient of the Licensed Material.
+
+          6.  No endorsement. Nothing in this Public License constitutes or may be construed as permission to assert or imply that You are, or that Your use of the Licensed Material is, connected with, or sponsored, endorsed, or granted official status by, the Licensor or others designated to receive attribution as provided in Section 3(a)(1)(A)(i).
+
+b. Other rights.
+
+          1. Moral rights, such as the right of integrity, are not licensed under this Public License, nor are publicity, privacy, and/or other similar personality rights; however, to the extent possible, the Licensor waives and/or agrees not to assert any such rights held by the Licensor to the limited extent necessary to allow You to exercise the Licensed Rights, but not otherwise.
+
+          2. Patent and trademark rights are not licensed under this Public License.
+
+          3. To the extent possible, the Licensor waives any right to collect royalties from You for the exercise of the Licensed Rights, whether directly or through a collecting society under any voluntary or waivable statutory or compulsory licensing scheme. In all other cases the Licensor expressly reserves any right to collect such royalties.
+
+Section 3 – License Conditions.
+
+Your exercise of the Licensed Rights is expressly made subject to the following conditions.
+
+     a.	Attribution.
+
+          1. If You Share the Licensed Material (including in modified form), You must:
+
+               A. retain the following if it is supplied by the Licensor with the Licensed Material:
+
+                    i. identification of the creator(s) of the Licensed Material and any others designated to receive attribution, in any reasonable manner requested by the Licensor (including by pseudonym if designated);
+
+                    ii. a copyright notice;
+
+                    iii. a notice that refers to this Public License;
+
+                    iv.	a notice that refers to the disclaimer of warranties;
+
+                    v. a URI or hyperlink to the Licensed Material to the extent reasonably practicable;
+
+               B. indicate if You modified the Licensed Material and retain an indication of any previous modifications; and
+
+               C. indicate the Licensed Material is licensed under this Public License, and include the text of, or the URI or hyperlink to, this Public License.
+
+          2. You may satisfy the conditions in Section 3(a)(1) in any reasonable manner based on the medium, means, and context in which You Share the Licensed Material. For example, it may be reasonable to satisfy the conditions by providing a URI or hyperlink to a resource that includes the required information.
+
+          3. If requested by the Licensor, You must remove any of the information required by Section 3(a)(1)(A) to the extent reasonably practicable.
+
+          4. If You Share Adapted Material You produce, the Adapter's License You apply must not prevent recipients of the Adapted Material from complying with this Public License.
+
+Section 4 – Sui Generis Database Rights.
+
+Where the Licensed Rights include Sui Generis Database Rights that apply to Your use of the Licensed Material:
+
+     a.	for the avoidance of doubt, Section 2(a)(1) grants You the right to extract, reuse, reproduce, and Share all or a substantial portion of the contents of the database;
+
+     b.	if You include all or a substantial portion of the database contents in a database in which You have Sui Generis Database Rights, then the database in which You have Sui Generis Database Rights (but not its individual contents) is Adapted Material; and
+
+     c.	You must comply with the conditions in Section 3(a) if You Share all or a substantial portion of the contents of the database.
+For the avoidance of doubt, this Section 4 supplements and does not replace Your obligations under this Public License where the Licensed Rights include other Copyright and Similar Rights.
+
+Section 5 – Disclaimer of Warranties and Limitation of Liability.
+
+     a.	Unless otherwise separately undertaken by the Licensor, to the extent possible, the Licensor offers the Licensed Material as-is and as-available, and makes no representations or warranties of any kind concerning the Licensed Material, whether express, implied, statutory, or other. This includes, without limitation, warranties of title, merchantability, fitness for a particular purpose, non-infringement, absence of latent or other defects, accuracy, or the presence or absence of errors, whether or not known or discoverable. Where disclaimers of warranties are not allowed in full or in part, this disclaimer may not apply to You.
+
+     b.	To the extent possible, in no event will the Licensor be liable to You on any legal theory (including, without limitation, negligence) or otherwise for any direct, special, indirect, incidental, consequential, punitive, exemplary, or other losses, costs, expenses, or damages arising out of this Public License or use of the Licensed Material, even if the Licensor has been advised of the possibility of such losses, costs, expenses, or damages. Where a limitation of liability is not allowed in full or in part, this limitation may not apply to You.
+
+     c.	The disclaimer of warranties and limitation of liability provided above shall be interpreted in a manner that, to the extent possible, most closely approximates an absolute disclaimer and waiver of all liability.
+
+Section 6 – Term and Termination.
+
+     a.	This Public License applies for the term of the Copyright and Similar Rights licensed here. However, if You fail to comply with this Public License, then Your rights under this Public License terminate automatically.
+
+     b.	Where Your right to use the Licensed Material has terminated under Section 6(a), it reinstates:
+
+          1. automatically as of the date the violation is cured, provided it is cured within 30 days of Your discovery of the violation; or
+
+          2. upon express reinstatement by the Licensor.
+
+     c.	For the avoidance of doubt, this Section 6(b) does not affect any right the Licensor may have to seek remedies for Your violations of this Public License.
+
+     d.	For the avoidance of doubt, the Licensor may also offer the Licensed Material under separate terms or conditions or stop distributing the Licensed Material at any time; however, doing so will not terminate this Public License.
+
+     e.	Sections 1, 5, 6, 7, and 8 survive termination of this Public License.
+
+Section 7 – Other Terms and Conditions.
+
+     a.	The Licensor shall not be bound by any additional or different terms or conditions communicated by You unless expressly agreed.
+
+     b.	Any arrangements, understandings, or agreements regarding the Licensed Material not stated herein are separate from and independent of the terms and conditions of this Public License.
+
+Section 8 – Interpretation.
+
+     a.	For the avoidance of doubt, this Public License does not, and shall not be interpreted to, reduce, limit, restrict, or impose conditions on any use of the Licensed Material that could lawfully be made without permission under this Public License.
+
+     b.	To the extent possible, if any provision of this Public License is deemed unenforceable, it shall be automatically reformed to the minimum extent necessary to make it enforceable. If the provision cannot be reformed, it shall be severed from this Public License without affecting the enforceability of the remaining terms and conditions.
+
+     c.	No term or condition of this Public License will be waived and no failure to comply consented to unless expressly agreed to by the Licensor.
+
+     d.	Nothing in this Public License constitutes or may be interpreted as a limitation upon, or waiver of, any privileges and immunities that apply to the Licensor or You, including from the legal processes of any jurisdiction or authority.
+
+Creative Commons is not a party to its public licenses. Notwithstanding, Creative Commons may elect to apply one of its public licenses to material it publishes and in those instances will be considered the “Licensor.” Except for the limited purpose of indicating that material is shared under a Creative Commons public license or as otherwise permitted by the Creative Commons policies published at creativecommons.org/policies, Creative Commons does not authorize the use of the trademark “Creative Commons” or any other trademark or logo of Creative Commons without its prior written consent including, without limitation, in connection with any unauthorized modifications to any of its public licenses or any other arrangements, understandings, or agreements concerning use of licensed material. For the avoidance of doubt, this paragraph does not form part of the public licenses.
+
+Creative Commons may be contacted at creativecommons.org.

--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) 2021 Johnny Chan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/NodeGraphQt/__init__.py
+++ b/NodeGraphQt/__init__.py
@@ -1,7 +1,8 @@
-#!/usr/bin/python
-# -*- coding: utf-8 -*-
+#! /usr/bin/python3
+# SPDX-FileCopyrightText: 2021 Johnny Chan
+# SPDX-License-Identifier: MIT
 
-# (c) 2017, Johnny Chan and some awesome contributors (^_^)
+# (c) 2021, Johnny Chan and some awesome contributors (^_^)
 # https://github.com/jchanvfx/NodeGraphQt/graphs/contributors
 
 # Redistribution and use in source and binary forms, with or without

--- a/NodeGraphQt/base/__init__.py
+++ b/NodeGraphQt/base/__init__.py
@@ -1,30 +1,3 @@
-#!/usr/bin/python
-
-# (c) 2017, Johnny Chan
-# https://github.com/jchanvfx/NodeGraphQt
-
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-
-# * Redistributions of source code must retain the above copyright notice,
-#   this list of conditions and the following disclaimer.
-
-# * Redistributions in binary form must reproduce the above copyright notice,
-#   this list of conditions and the following disclaimer in the documentation
-#   and/or other materials provided with the distribution.
-
-# * Neither the name of the Johnny Chan nor the names of its contributors
-#   may be used to endorse or promote products derived from this software
-#   without specific prior written permission.
-
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS
-# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-# OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-# OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
-# OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
-# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
-# OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
-# EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#! /usr/bin/python3
+# SPDX-FileCopyrightText: 2021 Johnny Chan
+# SPDX-License-Identifier: MIT

--- a/NodeGraphQt/base/commands.py
+++ b/NodeGraphQt/base/commands.py
@@ -1,4 +1,7 @@
-#!/usr/bin/python
+#! /usr/bin/python3
+# SPDX-FileCopyrightText: 2021 Johnny Chan
+# SPDX-License-Identifier: MIT
+
 from Qt import QtWidgets
 
 from .utils import minimize_node_ref_count

--- a/NodeGraphQt/base/factory.py
+++ b/NodeGraphQt/base/factory.py
@@ -1,4 +1,7 @@
-#!/usr/bin/python
+#! /usr/bin/python3
+# SPDX-FileCopyrightText: 2021 Johnny Chan
+# SPDX-License-Identifier: MIT
+
 from ..errors import NodeRegistrationError
 
 

--- a/NodeGraphQt/base/graph.py
+++ b/NodeGraphQt/base/graph.py
@@ -1,5 +1,7 @@
-#!/usr/bin/python
-# -*- coding: utf-8 -*-
+#! /usr/bin/python3
+# SPDX-FileCopyrightText: 2021 Johnny Chan
+# SPDX-License-Identifier: MIT
+
 import copy
 import gc
 import json

--- a/NodeGraphQt/base/menu.py
+++ b/NodeGraphQt/base/menu.py
@@ -1,4 +1,7 @@
-#!/usr/bin/python
+#! /usr/bin/python3
+# SPDX-FileCopyrightText: 2021 Johnny Chan
+# SPDX-License-Identifier: MIT
+
 from distutils.version import LooseVersion
 
 from Qt import QtGui, QtCore

--- a/NodeGraphQt/base/model.py
+++ b/NodeGraphQt/base/model.py
@@ -1,4 +1,7 @@
-#!/usr/bin/python
+#! /usr/bin/python3
+# SPDX-FileCopyrightText: 2021 Johnny Chan
+# SPDX-License-Identifier: MIT
+
 import json
 from collections import defaultdict
 

--- a/NodeGraphQt/base/node.py
+++ b/NodeGraphQt/base/node.py
@@ -1,4 +1,7 @@
-#!/usr/bin/python
+#! /usr/bin/python3
+# SPDX-FileCopyrightText: 2021 Johnny Chan
+# SPDX-License-Identifier: MIT
+
 from collections import OrderedDict
 
 from .commands import PropertyChangedCmd

--- a/NodeGraphQt/base/port.py
+++ b/NodeGraphQt/base/port.py
@@ -1,4 +1,7 @@
-#!/usr/bin/python
+#! /usr/bin/python3
+# SPDX-FileCopyrightText: 2021 Johnny Chan
+# SPDX-License-Identifier: MIT
+
 from .commands import (PortConnectedCmd,
                        PortDisconnectedCmd,
                        PortLockedCmd,

--- a/NodeGraphQt/base/utils.py
+++ b/NodeGraphQt/base/utils.py
@@ -1,4 +1,7 @@
-#!/usr/bin/python
+#! /usr/bin/python3
+# SPDX-FileCopyrightText: 2021 Johnny Chan
+# SPDX-License-Identifier: MIT
+
 from distutils.version import LooseVersion
 
 from Qt import QtGui, QtCore

--- a/NodeGraphQt/constants.py
+++ b/NodeGraphQt/constants.py
@@ -1,9 +1,9 @@
-#!/usr/bin/python
-# -*- coding: utf-8 -*-
+#! /usr/bin/python3
+# SPDX-FileCopyrightText: 2021 Johnny Chan
+# SPDX-License-Identifier: MIT
+
 import os
-
 from Qt import QtWidgets
-
 from .pkg_info import __version__
 
 __doc__ = """

--- a/NodeGraphQt/errors.py
+++ b/NodeGraphQt/errors.py
@@ -1,5 +1,6 @@
-#!/usr/bin/python
-# -*- coding: utf-8 -*-
+#! /usr/bin/python3
+# SPDX-FileCopyrightText: 2021 Johnny Chan
+# SPDX-License-Identifier: MIT
 
 
 class NodeMenuError(Exception): pass

--- a/NodeGraphQt/pkg_info.py
+++ b/NodeGraphQt/pkg_info.py
@@ -1,5 +1,7 @@
-#!/usr/bin/python
-# -*- coding: utf-8 -*-
+#! /usr/bin/python3
+# SPDX-FileCopyrightText: 2021 Johnny Chan
+# SPDX-License-Identifier: MIT
+
 __version__ = '0.1.7'
 __status__ = 'Work in Progress'
 __license__ = 'MIT'

--- a/NodeGraphQt/qgraphics/__init__.py
+++ b/NodeGraphQt/qgraphics/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2021 Johnny Chan
+# SPDX-License-Identifier: MIT

--- a/NodeGraphQt/qgraphics/node_abstract.py
+++ b/NodeGraphQt/qgraphics/node_abstract.py
@@ -1,4 +1,7 @@
-#!/usr/bin/python
+#! /usr/bin/python3
+# SPDX-FileCopyrightText: 2021 Johnny Chan
+# SPDX-License-Identifier: MIT
+
 from Qt import QtCore, QtWidgets
 
 from ..constants import (Z_VAL_NODE, NODE_WIDTH, NODE_HEIGHT, ITEM_CACHE_MODE)

--- a/NodeGraphQt/qgraphics/node_backdrop.py
+++ b/NodeGraphQt/qgraphics/node_backdrop.py
@@ -1,4 +1,7 @@
-#!/usr/bin/python
+#! /usr/bin/python3
+# SPDX-FileCopyrightText: 2021 Johnny Chan
+# SPDX-License-Identifier: MIT
+
 from Qt import QtGui, QtCore, QtWidgets
 
 from .node_abstract import AbstractNodeItem

--- a/NodeGraphQt/qgraphics/node_base.py
+++ b/NodeGraphQt/qgraphics/node_base.py
@@ -1,4 +1,7 @@
-#!/usr/bin/python
+#! /usr/bin/python3
+# SPDX-FileCopyrightText: 2021 Johnny Chan
+# SPDX-License-Identifier: MIT
+
 from collections import OrderedDict
 
 from Qt import QtGui, QtCore, QtWidgets

--- a/NodeGraphQt/qgraphics/node_overlay_disabled.py
+++ b/NodeGraphQt/qgraphics/node_overlay_disabled.py
@@ -1,6 +1,8 @@
-#!/usr/bin/python
-from Qt import QtGui, QtCore, QtWidgets
+#! /usr/bin/python3
+# SPDX-FileCopyrightText: 2021 Johnny Chan
+# SPDX-License-Identifier: MIT
 
+from Qt import QtGui, QtCore, QtWidgets
 from ..constants import Z_VAL_NODE_WIDGET
 
 

--- a/NodeGraphQt/qgraphics/node_text_item.py
+++ b/NodeGraphQt/qgraphics/node_text_item.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2021 Johnny Chan
+# SPDX-License-Identifier: MIT
+
 from Qt import QtWidgets, QtCore, QtGui
 
 

--- a/NodeGraphQt/qgraphics/pipe.py
+++ b/NodeGraphQt/qgraphics/pipe.py
@@ -1,4 +1,7 @@
-#!/usr/bin/python
+#! /usr/bin/python3
+# SPDX-FileCopyrightText: 2021 Johnny Chan
+# SPDX-License-Identifier: MIT
+
 import math
 
 from Qt import QtCore, QtGui, QtWidgets

--- a/NodeGraphQt/qgraphics/port.py
+++ b/NodeGraphQt/qgraphics/port.py
@@ -1,4 +1,7 @@
-#!/usr/bin/python
+#! /usr/bin/python3
+# SPDX-FileCopyrightText: 2021 Johnny Chan
+# SPDX-License-Identifier: MIT
+
 from Qt import QtGui, QtCore, QtWidgets
 
 from ..constants import (

--- a/NodeGraphQt/qgraphics/slicer.py
+++ b/NodeGraphQt/qgraphics/slicer.py
@@ -1,4 +1,7 @@
-#!/usr/bin/python
+#! /usr/bin/python3
+# SPDX-FileCopyrightText: 2021 Johnny Chan
+# SPDX-License-Identifier: MIT
+
 import math
 
 from Qt import QtCore, QtGui, QtWidgets

--- a/NodeGraphQt/widgets/__init__.py
+++ b/NodeGraphQt/widgets/__init__.py
@@ -1,30 +1,3 @@
-#!/usr/bin/python
-
-# (c) 2017, Johnny Chan
-# https://github.com/jchanvfx/NodeGraphQt
-
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-
-# * Redistributions of source code must retain the above copyright notice,
-#   this list of conditions and the following disclaimer.
-
-# * Redistributions in binary form must reproduce the above copyright notice,
-#   this list of conditions and the following disclaimer in the documentation
-#   and/or other materials provided with the distribution.
-
-# * Neither the name of the Johnny Chan nor the names of its contributors
-#   may be used to endorse or promote products derived from this software
-#   without specific prior written permission.
-
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS
-# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-# OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-# OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
-# OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
-# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
-# OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
-# EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#! /usr/bin/python3
+# SPDX-FileCopyrightText: 2021 Johnny Chan
+# SPDX-License-Identifier: MIT

--- a/NodeGraphQt/widgets/actions.py
+++ b/NodeGraphQt/widgets/actions.py
@@ -1,4 +1,7 @@
-#!/usr/bin/python
+#! /usr/bin/python3
+# SPDX-FileCopyrightText: 2021 Johnny Chan
+# SPDX-License-Identifier: MIT
+
 from Qt import QtCore, QtWidgets
 from .stylesheet import STYLE_QMENU
 

--- a/NodeGraphQt/widgets/dialogs.py
+++ b/NodeGraphQt/widgets/dialogs.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2021 Johnny Chan
+# SPDX-License-Identifier: MIT
+
 import os
 
 from .stylesheet import STYLE_MESSAGEBOX

--- a/NodeGraphQt/widgets/node_publish_widget.py
+++ b/NodeGraphQt/widgets/node_publish_widget.py
@@ -1,5 +1,8 @@
-import os
+#! /usr/bin/python3
+# SPDX-FileCopyrightText: 2021 Johnny Chan
+# SPDX-License-Identifier: MIT
 
+import os
 from .properties import PropFileSavePath
 from Qt import QtWidgets
 

--- a/NodeGraphQt/widgets/node_space_bar.py
+++ b/NodeGraphQt/widgets/node_space_bar.py
@@ -1,5 +1,8 @@
-from Qt import QtWidgets, QtCore
+#! /usr/bin/python3
+# SPDX-FileCopyrightText: 2021 Johnny Chan
+# SPDX-License-Identifier: MIT
 
+from Qt import QtWidgets, QtCore
 from .stylesheet import STYLE_SLASH_BUTTON, STYLE_NODE_BUTTON
 
 

--- a/NodeGraphQt/widgets/node_widgets.py
+++ b/NodeGraphQt/widgets/node_widgets.py
@@ -1,4 +1,7 @@
-#!/usr/bin/python
+#! /usr/bin/python3
+# SPDX-FileCopyrightText: 2021 Johnny Chan
+# SPDX-License-Identifier: MIT
+
 from .dialogs import FileDialog
 from .properties import _ValueEdit
 from .stylesheet import *

--- a/NodeGraphQt/widgets/nodes_palette.py
+++ b/NodeGraphQt/widgets/nodes_palette.py
@@ -1,9 +1,9 @@
-#!/usr/bin/python
-# -*- coding: utf-8 -*-
+#! /usr/bin/python3
+# SPDX-FileCopyrightText: 2021 Johnny Chan
+# SPDX-License-Identifier: MIT
+
 from collections import defaultdict
-
 from Qt import QtWidgets, QtCore, QtGui
-
 from ..constants import URN_SCHEME
 
 

--- a/NodeGraphQt/widgets/nodes_tree.py
+++ b/NodeGraphQt/widgets/nodes_tree.py
@@ -1,5 +1,7 @@
-#!/usr/bin/python
-# -*- coding: utf-8 -*-
+#! /usr/bin/python3
+# SPDX-FileCopyrightText: 2021 Johnny Chan
+# SPDX-License-Identifier: MIT
+
 from Qt import QtWidgets, QtCore, QtGui
 
 from ..constants import URN_SCHEME

--- a/NodeGraphQt/widgets/properties.py
+++ b/NodeGraphQt/widgets/properties.py
@@ -1,4 +1,7 @@
-#!/usr/bin/python
+#! /usr/bin/python3
+# SPDX-FileCopyrightText: 2021 Johnny Chan
+# SPDX-License-Identifier: MIT
+
 from collections import defaultdict
 
 from Qt import QtWidgets, QtCore, QtGui

--- a/NodeGraphQt/widgets/properties_bin.py
+++ b/NodeGraphQt/widgets/properties_bin.py
@@ -1,4 +1,7 @@
-#!/usr/bin/python
+#! /usr/bin/python3
+# SPDX-FileCopyrightText: 2021 Johnny Chan
+# SPDX-License-Identifier: MIT
+
 from Qt import QtWidgets, QtCore, QtGui, QtCompat
 
 from .properties import NodePropWidget

--- a/NodeGraphQt/widgets/scene.py
+++ b/NodeGraphQt/widgets/scene.py
@@ -1,4 +1,7 @@
-#!/usr/bin/python
+#! /usr/bin/python3
+# SPDX-FileCopyrightText: 2021 Johnny Chan
+# SPDX-License-Identifier: MIT
+
 from Qt import QtGui, QtCore, QtWidgets
 
 from ..constants import (VIEWER_BG_COLOR,

--- a/NodeGraphQt/widgets/stylesheet.py
+++ b/NodeGraphQt/widgets/stylesheet.py
@@ -1,5 +1,7 @@
-import re
+# SPDX-FileCopyrightText: 2021 Johnny Chan
+# SPDX-License-Identifier: MIT
 
+import re
 from ..constants import ICON_DOWN_ARROW
 
 # Reformat the icon path on Windows OS.

--- a/NodeGraphQt/widgets/tab_search.py
+++ b/NodeGraphQt/widgets/tab_search.py
@@ -1,4 +1,7 @@
-#!/usr/bin/python
+#! /usr/bin/python3
+# SPDX-FileCopyrightText: 2021 Johnny Chan
+# SPDX-License-Identifier: MIT
+
 import re
 from collections import OrderedDict
 

--- a/NodeGraphQt/widgets/viewer.py
+++ b/NodeGraphQt/widgets/viewer.py
@@ -1,5 +1,7 @@
-#!/usr/bin/python
-# -*- coding: utf-8 -*-
+#! /usr/bin/python3
+# SPDX-FileCopyrightText: 2021 Johnny Chan
+# SPDX-License-Identifier: MIT
+
 import math
 
 import Qt

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2021 Johnny Chan -->
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+
 ## NodeGraphQt
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE.md) 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,5 +1,7 @@
+# SPDX-FileCopyrightText: 2021 The Sphinx Authors
+# SPDX-License-Identifier: CC-BY-4.0
+
 # Minimal makefile for Sphinx documentation
-#
 
 # You can set these variables from the command line.
 SPHINXOPTS    =

--- a/docs/constants.rst
+++ b/docs/constants.rst
@@ -1,3 +1,6 @@
+.. SPDX-FileCopyrightText: 2021 Johnny Chan
+.. SPDX-License-Identifier: CC-BY-4.0
+
 Constants
 #########
 

--- a/docs/custom_widgets.rst
+++ b/docs/custom_widgets.rst
@@ -1,3 +1,6 @@
+.. SPDX-FileCopyrightText: 2021 Johnny Chan
+.. SPDX-License-Identifier: CC-BY-4.0
+
 Custom Widgets
 ##############
 

--- a/docs/examples/ex_menu.rst
+++ b/docs/examples/ex_menu.rst
@@ -1,3 +1,6 @@
+.. SPDX-FileCopyrightText: 2021 Johnny Chan
+.. SPDX-License-Identifier: CC-BY-4.0
+
 Menu Examples
 #############
 

--- a/docs/examples/ex_node.rst
+++ b/docs/examples/ex_node.rst
@@ -1,3 +1,6 @@
+.. SPDX-FileCopyrightText: 2021 Johnny Chan
+.. SPDX-License-Identifier: CC-BY-4.0
+
 Node Examples
 #############
 

--- a/docs/examples/ex_overview.rst
+++ b/docs/examples/ex_overview.rst
@@ -1,3 +1,6 @@
+.. SPDX-FileCopyrightText: 2021 Johnny Chan
+.. SPDX-License-Identifier: CC-BY-4.0
+
 Basic Overview
 ##############
 

--- a/docs/examples/ex_pipe.rst
+++ b/docs/examples/ex_pipe.rst
@@ -1,3 +1,6 @@
+.. SPDX-FileCopyrightText: 2021 Johnny Chan
+.. SPDX-License-Identifier: CC-BY-4.0
+
 Pipe Examples
 #############
 

--- a/docs/examples/ex_port.rst
+++ b/docs/examples/ex_port.rst
@@ -1,3 +1,6 @@
+.. SPDX-FileCopyrightText: 2021 Johnny Chan
+.. SPDX-License-Identifier: CC-BY-4.0
+
 Port Examples
 #############
 

--- a/docs/graph.rst
+++ b/docs/graph.rst
@@ -1,3 +1,6 @@
+.. SPDX-FileCopyrightText: 2021 Johnny Chan
+.. SPDX-License-Identifier: CC-BY-4.0
+
 Graphs
 ######
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,3 +1,6 @@
+.. SPDX-FileCopyrightText: 2021 Johnny Chan
+.. SPDX-License-Identifier: CC-BY-4.0
+
 NodeGraphQt |version_str|
 #########################
 

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,8 +1,10 @@
-@ECHO OFF
+@echo off
+
+REM SPDX-FileCopyrightText: 2021 The Sphinx Authors
+REM SPDX-License-Identifier: CC-BY-4.0
+REM Command file for Sphinx documentation
 
 pushd %~dp0
-
-REM Command file for Sphinx documentation
 
 if "%SPHINXBUILD%" == "" (
 	set SPHINXBUILD=sphinx-build

--- a/docs/menu.rst
+++ b/docs/menu.rst
@@ -1,3 +1,6 @@
+.. SPDX-FileCopyrightText: 2021 Johnny Chan
+.. SPDX-License-Identifier: CC-BY-4.0
+
 Menus
 #####
 

--- a/docs/node_widgets.rst
+++ b/docs/node_widgets.rst
@@ -1,3 +1,6 @@
+.. SPDX-FileCopyrightText: 2021 Johnny Chan
+.. SPDX-License-Identifier: CC-BY-4.0
+
 Node Embedded Widgets
 #####################
 

--- a/docs/nodes.rst
+++ b/docs/nodes.rst
@@ -1,3 +1,6 @@
+.. SPDX-FileCopyrightText: 2021 Johnny Chan
+.. SPDX-License-Identifier: CC-BY-4.0
+
 Nodes
 #####
 

--- a/docs/nodes/BackdropNode.rst
+++ b/docs/nodes/BackdropNode.rst
@@ -1,3 +1,6 @@
+.. SPDX-FileCopyrightText: 2021 Johnny Chan
+.. SPDX-License-Identifier: CC-BY-4.0
+
 BackdropNode
 ############
 

--- a/docs/nodes/BaseNode.rst
+++ b/docs/nodes/BaseNode.rst
@@ -1,3 +1,6 @@
+.. SPDX-FileCopyrightText: 2021 Johnny Chan
+.. SPDX-License-Identifier: CC-BY-4.0
+
 BaseNode
 ########
 

--- a/docs/nodes/NodeObject.rst
+++ b/docs/nodes/NodeObject.rst
@@ -1,3 +1,6 @@
+.. SPDX-FileCopyrightText: 2021 Johnny Chan
+.. SPDX-License-Identifier: CC-BY-4.0
+
 NodeObject
 ##########
 

--- a/docs/nodes/Port.rst
+++ b/docs/nodes/Port.rst
@@ -1,3 +1,6 @@
+.. SPDX-FileCopyrightText: 2021 Johnny Chan
+.. SPDX-License-Identifier: CC-BY-4.0
+
 Port
 ####
 

--- a/example.py
+++ b/example.py
@@ -1,5 +1,7 @@
-#!/usr/bin/python
-# -*- coding: utf-8 -*-
+#! /usr/bin/python3
+# SPDX-FileCopyrightText: 2021 Johnny Chan
+# SPDX-License-Identifier: MIT
+
 import os
 
 from Qt import QtCore, QtGui, QtWidgets

--- a/example_auto_nodes.py
+++ b/example_auto_nodes.py
@@ -1,5 +1,7 @@
-#!/usr/bin/python
-# -*- coding: utf-8 -*-
+#! /usr/bin/python3
+# SPDX-FileCopyrightText: 2021 Johnny Chan
+# SPDX-License-Identifier: MIT
+
 from NodeGraphQt import NodeGraph, setup_context_menu, \
     QtWidgets, QtCore, PropertiesBinWidget, BackdropNode
 from example_auto_nodes import Publish, RootNode, update_nodes, setup_node_menu

--- a/example_auto_nodes/__init__.py
+++ b/example_auto_nodes/__init__.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2021 Johnny Chan
+# SPDX-License-Identifier: MIT
+
 from .node_base import AutoNode, ModuleNode, SubGraphNode, RootNode
 from .subgraph_nodes import Publish
 from .node_base.utils import update_node_down_stream, update_nodes, setup_node_menu

--- a/example_auto_nodes/basic_nodes.py
+++ b/example_auto_nodes/basic_nodes.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2021 Johnny Chan
+# SPDX-License-Identifier: MIT
+
 from .node_base import AutoNode
 
 

--- a/example_auto_nodes/data_node.py
+++ b/example_auto_nodes/data_node.py
@@ -1,5 +1,7 @@
-#!/usr/bin/python
-# -*- coding: utf-8 -*-
+#! /usr/bin/python3
+# SPDX-FileCopyrightText: 2021 Johnny Chan
+# SPDX-License-Identifier: MIT
+
 from .node_base import AutoNode
 
 

--- a/example_auto_nodes/input_nodes.py
+++ b/example_auto_nodes/input_nodes.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2021 Johnny Chan
+# SPDX-License-Identifier: MIT
+
 from NodeGraphQt import QtCore
 from NodeGraphQt.constants import (NODE_PROP_VECTOR2,
                                    NODE_PROP_VECTOR3,

--- a/example_auto_nodes/logic_nodes.py
+++ b/example_auto_nodes/logic_nodes.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2021 Johnny Chan
+# SPDX-License-Identifier: MIT
+
 from .node_base import AutoNode
 
 

--- a/example_auto_nodes/module_nodes.py
+++ b/example_auto_nodes/module_nodes.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2021 Johnny Chan
+# SPDX-License-Identifier: MIT
+
 from .node_base import (ModuleNode,
                         get_functions_from_module,
                         get_functions_from_type)

--- a/example_auto_nodes/node_base/__init__.py
+++ b/example_auto_nodes/node_base/__init__.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2021 Johnny Chan
+# SPDX-License-Identifier: MIT
+
 from .auto_node import AutoNode
 from .module_node import ModuleNode, get_functions_from_module, get_functions_from_type
 from .subgraph_node import SubGraphNode, SubGraphInputNode, SubGraphOutputNode, RootNode

--- a/example_auto_nodes/node_base/auto_node.py
+++ b/example_auto_nodes/node_base/auto_node.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2021 Johnny Chan
+# SPDX-License-Identifier: MIT
+
 import copy
 import time
 import traceback

--- a/example_auto_nodes/node_base/module_node.py
+++ b/example_auto_nodes/node_base/module_node.py
@@ -1,5 +1,7 @@
-import inspect
+# SPDX-FileCopyrightText: 2021 Johnny Chan
+# SPDX-License-Identifier: MIT
 
+import inspect
 from .auto_node import AutoNode
 
 

--- a/example_auto_nodes/node_base/subgraph_node.py
+++ b/example_auto_nodes/node_base/subgraph_node.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2021 Johnny Chan
+# SPDX-License-Identifier: MIT
+
 import json
 
 from NodeGraphQt import SubGraph

--- a/example_auto_nodes/node_base/utils.py
+++ b/example_auto_nodes/node_base/utils.py
@@ -1,5 +1,7 @@
-import hashlib
+# SPDX-FileCopyrightText: 2021 Johnny Chan
+# SPDX-License-Identifier: MIT
 
+import hashlib
 from NodeGraphQt import topological_sort_by_down, NodePublishWidget
 
 

--- a/example_auto_nodes/subgraph_nodes.py
+++ b/example_auto_nodes/subgraph_nodes.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2021 Johnny Chan
+# SPDX-License-Identifier: MIT
+
 from .node_base import SubGraphNode, SubGraphInputNode, SubGraphOutputNode
 import json
 import os

--- a/example_auto_nodes/viewer_nodes.py
+++ b/example_auto_nodes/viewer_nodes.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2021 Johnny Chan
+# SPDX-License-Identifier: MIT
+
 from .node_base import AutoNode
 
 

--- a/example_auto_nodes/widget_nodes.py
+++ b/example_auto_nodes/widget_nodes.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2021 Johnny Chan
+# SPDX-License-Identifier: MIT
+
 from .node_base import AutoNode
 
 

--- a/example_auto_nodes/wrappers/__init__.py
+++ b/example_auto_nodes/wrappers/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2021 Johnny Chan
+# SPDX-License-Identifier: MIT

--- a/example_auto_nodes/wrappers/dict.py
+++ b/example_auto_nodes/wrappers/dict.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2021 Johnny Chan
+# SPDX-License-Identifier: MIT
+
 def clear(self):
     self.clear()
     return self

--- a/example_auto_nodes/wrappers/list.py
+++ b/example_auto_nodes/wrappers/list.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2021 Johnny Chan
+# SPDX-License-Identifier: MIT
+
 def append(self, object):
     self.append(object)
     return self

--- a/example_auto_nodes/wrappers/math.py
+++ b/example_auto_nodes/wrappers/math.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2021 Johnny Chan
+# SPDX-License-Identifier: MIT
+
 from math import *
 
 _pi = pi

--- a/example_auto_nodes/wrappers/str.py
+++ b/example_auto_nodes/wrappers/str.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2021 Johnny Chan
+# SPDX-License-Identifier: MIT
+
 
 def capitalize(self):
     return self.capitalize()

--- a/example_auto_nodes/wrappers/tuple.py
+++ b/example_auto_nodes/wrappers/tuple.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2021 Johnny Chan
+# SPDX-License-Identifier: MIT
+
 def count(self, value):
     return self.count(value)
 

--- a/example_math_nodes.py
+++ b/example_math_nodes.py
@@ -1,5 +1,7 @@
-#!/usr/bin/python
-# -*- coding: utf-8 -*-
+#! /usr/bin/python3
+# SPDX-FileCopyrightText: 2021 Johnny Chan
+# SPDX-License-Identifier: MIT
+
 from Qt import QtWidgets, QtCore
 
 from NodeGraphQt import (NodeGraph,

--- a/example_nodes/__init__.py
+++ b/example_nodes/__init__.py
@@ -1,4 +1,7 @@
-#!/usr/bin/python
+#! /usr/bin/python3
+# SPDX-FileCopyrightText: 2021 Johnny Chan
+# SPDX-License-Identifier: MIT
+
 import os
 import sys
 import ast

--- a/example_nodes/basic_nodes.py
+++ b/example_nodes/basic_nodes.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2021 Johnny Chan
+# SPDX-License-Identifier: MIT
+
 from NodeGraphQt import BaseNode
 
 

--- a/example_nodes/input_nodes.py
+++ b/example_nodes/input_nodes.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2021 Johnny Chan
+# SPDX-License-Identifier: MIT
+
 import os
 from NodeGraphQt import BaseNode, QtCore
 

--- a/example_nodes/logic_nodes.py
+++ b/example_nodes/logic_nodes.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2021 Johnny Chan
+# SPDX-License-Identifier: MIT
+
 from NodeGraphQt import BaseNode, QtCore
 
 

--- a/example_nodes/math_node.py
+++ b/example_nodes/math_node.py
@@ -1,5 +1,7 @@
-#!/usr/bin/python
-# -*- coding: utf-8 -*-
+#! /usr/bin/python3
+# SPDX-FileCopyrightText: 2021 Johnny Chan
+# SPDX-License-Identifier: MIT
+
 import example_nodes.wrappers.math as math
 import inspect
 from functools import partial

--- a/example_nodes/util_nodes.py
+++ b/example_nodes/util_nodes.py
@@ -1,5 +1,7 @@
-#!/usr/bin/python
-# -*- coding: utf-8 -*-
+#! /usr/bin/python3
+# SPDX-FileCopyrightText: 2021 Johnny Chan
+# SPDX-License-Identifier: MIT
+
 import inspect
 from NodeGraphQt import BaseNode
 

--- a/example_nodes/viewer_nodes.py
+++ b/example_nodes/viewer_nodes.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2021 Johnny Chan
+# SPDX-License-Identifier: MIT
+
 from NodeGraphQt import BaseNode
 
 

--- a/example_nodes/widget_nodes.py
+++ b/example_nodes/widget_nodes.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2021 Johnny Chan
+# SPDX-License-Identifier: MIT
+
 from NodeGraphQt import BaseNode
 
 

--- a/example_nodes/wrappers/__init__.py
+++ b/example_nodes/wrappers/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2021 Johnny Chan
+# SPDX-License-Identifier: MIT

--- a/example_nodes/wrappers/math.py
+++ b/example_nodes/wrappers/math.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2021 Johnny Chan
+# SPDX-License-Identifier: MIT
+
 from math import *
 
 _pi = pi

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: 2021 Johnny Chan
+# SPDX-License-Identifier: MIT
+
 Qt.py>=1.2.0

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,7 @@
-#!/usr/bin/python
-# -*- coding: utf-8 -*-
+#! /usr/bin/python3
+# SPDX-FileCopyrightText: 2021 Johnny Chan
+# SPDX-License-Identifier: MIT
+
 import os
 import sys
 


### PR DESCRIPTION
See https://reuse.software and https://spdx.dev

Unless I missed something, the docs had no license information yet, so I am suggesting CC-By-4.0, but this could of course be changed to any other license of your preference.

There are some files where I'm not sure who created them, thus this MR does not make the repository fuly reuse compliant yet. You can obtain a list of files that lack license/copyright data via `reuse lint` (requires the [reuse](https://pypi.org/project/reuse/) package).

I think the spec actually requests an author email to be given, but I couldn't find your address. If you could tell me your email I'll add it.

(Side-note: In case PR #222 gets merged, the location of `license_file﻿` would need to be changed accordingly.)