### PR TITLE
Remove call of non-existent method `port.delete()`

### DIFF
--- a/NodeGraphQt/qgraphics/node_base.py
+++ b/NodeGraphQt/qgraphics/node_base.py
@@ -676,7 +676,6 @@ class NodeItem(AbstractNodeItem):
             port (PortItem): port object.
             text (QtWidgets.QGraphicsTextItem): port text object.
         """
-        port.delete()
         port.setParentItem(None)
         text.setParentItem(None)
         self.scene().removeItem(port)


### PR DESCRIPTION
Issue: https://github.com/jchanvfx/NodeGraphQt/issues/234