### PR TITLE
Use higher-level functions to deserialize custom props and connections

### DIFF
--- a/NodeGraphQt/base/graph.py
+++ b/NodeGraphQt/base/graph.py
@@ -1370,7 +1370,7 @@ class NodeGraph(QtCore.QObject):
                         node.model.set_property(prop, n_data[prop])
                 # set custom properties.
                 for prop, val in n_data.get('custom', {}).items():
-                    node.model.set_property(prop, val)
+                    node.set_property(prop, val)
 
                 nodes[n_id] = node
 
@@ -1407,7 +1407,7 @@ class NodeGraph(QtCore.QObject):
             out_port = out_node.outputs().get(pname) if out_node else None
 
             if in_port and out_port:
-                self._undo_stack.push(PortConnectedCmd(in_port, out_port))
+                in_port.connect_to(out_port)
 
         node_objs = list(nodes.values())
         if relative_pos:


### PR DESCRIPTION
Hello!

First of all thanks for all the work put into this project so far! It has been a wonderful starting point for my own program. However, I have run into an issue with deserialisation: my Nodes implement the `on_input_connected`/`on_input_disconnected` handlers and also overwrite `set_property`. The logic in there is necessary for the computation modelled by the graph to work correctly. As it stands, the deserialisation bypasses this level of implementation, so deserialised graphs end up broken.

Here's the general gist for my nodes:

```python
class MyNode(BaseNode):
    # ... more implementation ...

    def on_input_connected(self, in_port, out_port):
        # triggers a recomputation of this node and downstream consumers
        self.invalidate_cache()
        return super().on_input_connected(in_port, out_port)

    # analogous `on_input_disconnected` implementation

    def set_property(self, name, value):
        # again, triggering a recompute
        self.invalidate_cache()
        # also making sure the UI stays in sync with the node state
        self.set_ui_elements( ... )
        return super().set_property(name, value)
```

I couldn't figure out how to solve my particular use case without such event handlers (and without adding another layer that only hosts my custom logic and a custom model for the underlying graph which would arguably be neater), so I propose to move the relevant function calls in the deserialisation to a higher level of abstraction. This would mean that more code gets run when loading a session, but it would also bring the deserialisation closer to the construction of the graph "by hand".