### PR TITLE
Fix missing setup.py

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,5 @@
 [metadata]
+name = NodeGraphQt
 license = MIT License
 license_file = LICENSE.md
 long_description = file: README.md

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,6 @@
 [metadata]
 name = NodeGraphQt
+version = 0.2.1
 license = MIT License
 license_file = LICENSE.md
 long_description = file: README.md

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,4 @@
+from setuptools import setup
+
+if __name__ == '__main__':
+    setup()


### PR DESCRIPTION
Hi,

First of all, thanks for the work, NodeGraphQt is very plug & play and easy to customize.

From version 0.1.8 to 0.2.0 we lost the ability to install NodeGraphQt using pip because "setup.py" is missing. 

Even tough there is a "setup.cfg" file, pip still needs a dummy "setup.py" file.

In this pull request, I've added the setup.py file and added two fields in the setup.cfg file : 

- name
- version

Best regards,

Samy