### PR TITLE
fix double emitting of value_changed event in _on_value_change function

### DIFF
--- a/NodeGraphQt/custom_widgets/properties_bin/custom_widget_vectors.py
+++ b/NodeGraphQt/custom_widgets/properties_bin/custom_widget_vectors.py
@@ -38,7 +38,6 @@ class _PropVector(BaseProperty):
             if index is not None:
                 self._value[index] = value
             self.value_changed.emit(self.toolTip(), self._value)
-        self.value_changed.emit(self.toolTip(), self._value)
 
     def _update_items(self):
         if not isinstance(self._value, (list, tuple)):

--- a/NodeGraphQt/custom_widgets/properties_bin/custom_widget_vectors.py
+++ b/NodeGraphQt/custom_widgets/properties_bin/custom_widget_vectors.py
@@ -36,6 +36,7 @@ class _PropVector(BaseProperty):
     def _on_value_change(self, value=None, index=None):
         if self._can_emit:
             if index is not None:
+                self._value = list(self._value)
                 self._value[index] = value
             self.value_changed.emit(self.toolTip(), self._value)
 
@@ -57,7 +58,6 @@ class _PropVector(BaseProperty):
         return self._value
 
     def set_value(self, value=None):
-        value = list(value)
         if value != self.get_value():
             self._value = value
             self._can_emit = False


### PR DESCRIPTION
Removed a line which caused that value_changed was emitted twice when a vector widget value was changed.

Also fixed a problem that the _value variable of a vector wasn't replaced with a new list when a _NumberValueEdit was changed directly. This caused that the NodeGraph class didn't emit the property_changed signal when changing the number fields of a PropColorPickerRGB widget more than once.
This is because this if condition would be false in these cases:
https://github.com/jchanvfx/NodeGraphQt/blob/0eb0262dbd2991a9c3fca89c12efd3f50cad2a4d/NodeGraphQt/base/graph.py#L257

I hope it makes sense, but I can provide more details if needed.