### PR TITLE
Add double slider widget

### DIFF
--- a/NodeGraphQt/constants.py
+++ b/NodeGraphQt/constants.py
@@ -230,21 +230,23 @@ class NodePropWidgetEnum(Enum):
     COLOR_PICKER = 9
     #: Node property represented with a ColorPicker (RGBA) widget.
     COLOR4_PICKER = 10
-    #: Node property represented with a Slider widget.
+    #: Node property represented with an (Int) Slider widget.
     SLIDER = 11
+    #: Node property represented with a (Dobule) Slider widget.
+    DOUBLE_SLIDER = 12
     #: Node property represented with a file selector widget.
-    FILE_OPEN = 12
+    FILE_OPEN = 13
     #: Node property represented with a file save widget.
-    FILE_SAVE = 13
+    FILE_SAVE = 14
     #: Node property represented with a vector2 widget.
-    VECTOR2 = 14
+    VECTOR2 = 15
     #: Node property represented with vector3 widget.
-    VECTOR3 = 15
+    VECTOR3 = 16
     #: Node property represented with vector4 widget.
-    VECTOR4 = 16
+    VECTOR4 = 17
     #: Node property represented with float line edit widget.
-    FLOAT = 17
+    FLOAT = 18
     #: Node property represented with int line edit widget.
-    INT = 18
+    INT = 19
     #: Node property represented with button widget.
-    BUTTON = 19
+    BUTTON = 20

--- a/NodeGraphQt/custom_widgets/properties_bin/node_property_factory.py
+++ b/NodeGraphQt/custom_widgets/properties_bin/node_property_factory.py
@@ -1,7 +1,7 @@
 from NodeGraphQt.constants import NodePropWidgetEnum
 from .custom_widget_color_picker import PropColorPickerRGB, PropColorPickerRGBA
 from .custom_widget_file_paths import PropFilePath, PropFileSavePath
-from .custom_widget_slider import PropSlider
+from .custom_widget_slider import PropSlider, PropDoubleSlider
 from .custom_widget_value_edit import FloatValueEdit, IntValueEdit
 from .custom_widget_vectors import PropVector2, PropVector3, PropVector4
 from .prop_widgets_base import (
@@ -36,6 +36,7 @@ class NodePropertyWidgetFactory(object):
             NodePropWidgetEnum.COLOR_PICKER.value: PropColorPickerRGB,
             NodePropWidgetEnum.COLOR4_PICKER.value: PropColorPickerRGBA,
             NodePropWidgetEnum.SLIDER.value: PropSlider,
+            NodePropWidgetEnum.DOUBLE_SLIDER.value: PropDoubleSlider,
             NodePropWidgetEnum.FILE_OPEN.value: PropFilePath,
             NodePropWidgetEnum.FILE_SAVE.value: PropFileSavePath,
             NodePropWidgetEnum.VECTOR2.value: PropVector2,

--- a/NodeGraphQt/custom_widgets/properties_bin/node_property_widgets.py
+++ b/NodeGraphQt/custom_widgets/properties_bin/node_property_widgets.py
@@ -588,6 +588,12 @@ if __name__ == '__main__':
                 widget_type=NodePropWidgetEnum.SLIDER.value
             )
             self.create_property(
+                'float_range',
+                value=150.5,
+                range=(50.5, 200),
+                widget_type=NodePropWidgetEnum.DOUBLE_SLIDER.value
+            )
+            self.create_property(
                 'color4_picker',
                 value=(255, 0, 0, 122),
                 widget_type=NodePropWidgetEnum.COLOR4_PICKER.value


### PR DESCRIPTION
Hey!

I've added a double/float slider widget. It's a mix between the QDoublespin_Box and the Slider widgets. We want to use it for our float data. 
Hope this is any helpful :) Let me know if you have any feedback! 

Currently it's necessary to specify the amount of decimals wanted.

I've attached a screenshot of the adjusted property test UI.
![image](https://user-images.githubusercontent.com/12091420/224507783-2c373c13-5967-4d10-846e-e4eefd3d6bde.png)

Cheers!
