### PR TITLE
Changed text color of the tab search to be more visable. Reference ta…

### DIFF
--- a/NodeGraphQt/widgets/tab_search.py
+++ b/NodeGraphQt/widgets/tab_search.py
@@ -57,7 +57,9 @@ class TabSearchLineEditWidget(QtWidgets.QLineEdit):
         super(TabSearchLineEditWidget, self).__init__(parent)
         self.setAttribute(QtCore.Qt.WA_MacShowFocusRect, 0)
         self.setMinimumSize(200, 22)
-        text_color = self.palette().text().color().getRgb()
+        # text_color = self.palette().text().color().getRgb()
+        text_color = tuple(map(lambda i, j: i - j, (255, 255, 255),
+                               ViewerEnum.BACKGROUND_COLOR.value))
         selected_color = self.palette().highlight().color().getRgb()
         style_dict = {
             'QLineEdit': {
@@ -108,7 +110,9 @@ class TabSearchMenuWidget(QtWidgets.QMenu):
         search_widget.setDefaultWidget(self.line_edit)
         self.addAction(search_widget)
 
-        text_color = self.palette().text().color().getRgb()
+        # text_color = self.palette().text().color().getRgb()
+        text_color = tuple(map(lambda i, j: i - j, (255, 255, 255),
+                               ViewerEnum.BACKGROUND_COLOR.value))
         selected_color = self.palette().highlight().color().getRgb()
         style_dict = {
             'QMenu': {


### PR DESCRIPTION
Hey again!

I've done a very small change so the text in the tab search menu is now more visible on the black background.
I found a similar change in [here](https://github.com/jchanvfx/NodeGraphQt/blob/master/NodeGraphQt/widgets/actions.py#L12), so I matched that.

Before:
![image](https://user-images.githubusercontent.com/12091420/224509600-83b78604-4098-43f5-9bf1-da830f81df80.png)

After:
![image](https://user-images.githubusercontent.com/12091420/224509612-82921296-0b2b-411f-9f05-f984c9672c63.png)
![image](https://user-images.githubusercontent.com/12091420/224509616-fce82b9e-9891-4b36-a818-7079e9921a2b.png)


Hope this helps! LMK if there's something I could add.
Cheers :)