### PR TITLE
Added file directory change to on_value_change callback for the FilePath Property

### DIFF
--- a/NodeGraphQt/custom_widgets/properties_bin/custom_widget_file_paths.py
+++ b/NodeGraphQt/custom_widgets/properties_bin/custom_widget_file_paths.py
@@ -42,6 +42,7 @@ class PropFilePath(BaseProperty):
     def _on_value_change(self, value=None):
         if value is None:
             value = self._ledit.text()
+        self.set_file_directory(value)
         self.value_changed.emit(self.toolTip(), value)
 
     def set_file_ext(self, ext=None):

--- a/NodeGraphQt/custom_widgets/properties_bin/node_property_widgets.py
+++ b/NodeGraphQt/custom_widgets/properties_bin/node_property_widgets.py
@@ -566,6 +566,11 @@ if __name__ == '__main__':
                 widget_type=NodePropWidgetEnum.QLABEL.value
             )
             self.create_property(
+                "file",
+                value="",
+                widget_type=NodePropWidgetEnum.FILE_OPEN.value
+            )
+            self.create_property(
                 'color_picker',
                 value=(0, 0, 255),
                 widget_type=NodePropWidgetEnum.COLOR_PICKER.value


### PR DESCRIPTION
Hey!

Sorry for the spam! :P

Another tiny change which adjusts the directory of the FilePathProp filedialog, whenever the property gets changed, even if not set via UI.

Small example image.
![image](https://user-images.githubusercontent.com/12091420/224511121-b6b272c5-2e08-4af9-8513-3608552adfe4.png)

Hope this helps :)

Manuel