### PR TITLE
Graph.paste_nodes() returns pasted node instances

### DIFF
--- a/NodeGraphQt/base/graph.py
+++ b/NodeGraphQt/base/graph.py
@@ -1788,6 +1788,9 @@ class NodeGraph(QtCore.QObject):
     def paste_nodes(self):
         """
         Pastes nodes copied from the clipboard.
+        
+        Returns:
+            list[NodeGraphQt.BaseNode]: list of pasted node instances.
         """
         clipboard = QtWidgets.QApplication.clipboard()
         cb_text = clipboard.text()
@@ -1806,6 +1809,7 @@ class NodeGraph(QtCore.QObject):
         nodes = self._deserialize(serial_data, relative_pos=True)
         [n.set_selected(True) for n in nodes]
         self._undo_stack.endMacro()
+        return nodes
 
     def duplicate_nodes(self, nodes):
         """


### PR DESCRIPTION
Hi,
is there a reason why `paste_nodes()` does not return node instances like `duplicate_nodes()` does? This small change takes care of that.

I find this possibility useful, because I am able to emit the `node_created` signal on those nodes and am able to check whether instances of the same type already exist in the graph and if so, to prevent pasting/duplicating of those nodes (in my application it does not make sense for certain nodes to be in the graph more than once...). That begs the question: shouldn't `paste_nodes()` and `duplicate_nodes()` emit `node_created` by default?