### PR TITLE
Fixed deserialization bug for nodes depending on on_input_connected

### DIFF
--- a/NodeGraphQt/base/graph.py
+++ b/NodeGraphQt/base/graph.py
@@ -1612,6 +1612,9 @@ class NodeGraph(QtCore.QObject):
                 if allow_connection:
                     self._undo_stack.push(PortConnectedCmd(in_port, out_port))
 
+                # Run on_input_connected to ensure connections are fully set up after deserialization.
+                in_node.on_input_connected(in_port, out_port)
+
         node_objs = nodes.values()
         if relative_pos:
             self._viewer.move_nodes([n.view for n in node_objs])


### PR DESCRIPTION
Nodes which depend on `on_input_connected` being called are not properly initialized after a load_session. 

I simply added `BaseNode.on_input_connected` call to `base.graph._deserialize()` (graph.py:1615, see diff) to fix this issue. Theoretically, when loading a session, I would imagine a graph should behave just as it does when created with `set_input` and `set_output`, this is my justification for believing on_input_connected should be called. (Personlly, rather than internally updating node connection dicts, I perhaps would use the API methods to build the session to unify the functionality in the first place.)

I had a [situation ](https://github.com/GRAYgoose124/cypress/blob/main/src/cypress/app/nodes/image.py#L122) which motivated this, several nodes which were using on_input_connected visually looked initialized, but were not behaving exactly as they do on first startup / creation until I manually reconnected them. My use case could be a result of bad design choices, I could grab the only node on the input connection dynamically - that did work  - rather than setting it on connection. (Maybe someone has a stern lecture for me on this design choice...) However, I do think this would be a bugfix regardless of my personal motivation. It seems to work robustly and I hope you consider including this change or a variation of it. 