### PR TITLE
Added adiditonal options to slider

### DIFF
--- a/NodeGraphQt/custom_widgets/properties_bin/custom_widget_slider.py
+++ b/NodeGraphQt/custom_widgets/properties_bin/custom_widget_slider.py
@@ -10,9 +10,11 @@ class PropSlider(BaseProperty):
     widget.
     """
 
-    def __init__(self, parent=None):
+    def __init__(self, parent=None, disable_scroll=True, realtime_update=False):
         super(PropSlider, self).__init__(parent)
         self._block = False
+        self._realtime_update = realtime_update
+        self._disable_scroll = disable_scroll
         self._slider = QtWidgets.QSlider()
         self._spinbox = QtWidgets.QSpinBox()
         self._init()
@@ -33,6 +35,10 @@ class PropSlider(BaseProperty):
         self._slider.mousePressEvent = self._on_slider_mouse_press
         self._slider.mouseReleaseEvent = self._on_slider_mouse_release
 
+        if self._disable_scroll:
+            self._slider.wheelEvent = lambda _: None
+            self._spinbox.wheelEvent = lambda _: None
+
     def _init_signal_connections(self):
         self._spinbox.valueChanged.connect(self._on_spnbox_changed)
         self._slider.valueChanged.connect(self._on_slider_changed)
@@ -42,11 +48,14 @@ class PropSlider(BaseProperty):
         self._slider_mouse_press_event(event)
 
     def _on_slider_mouse_release(self, event):
-        self.value_changed.emit(self.toolTip(), self.get_value())
+        if not self._realtime_update:
+            self.value_changed.emit(self.toolTip(), self.get_value())
         self._block = False
 
     def _on_slider_changed(self, value):
         self._spinbox.setValue(value)
+        if self._realtime_update:
+            self.value_changed.emit(self.toolTip(), self.get_value())
 
     def _on_spnbox_changed(self, value):
         if value != self._slider.value():

--- a/NodeGraphQt/custom_widgets/properties_bin/custom_widget_slider.py
+++ b/NodeGraphQt/custom_widgets/properties_bin/custom_widget_slider.py
@@ -115,10 +115,12 @@ class QDoubleSlider(QtWidgets.QSlider):
 
 
 class PropDoubleSlider(PropSlider):
-    def __init__(self, parent=None, decimals=2):
+    def __init__(self, parent=None, decimals=2, disable_scroll=True, realtime_update=False):
         # Do not initialize Propslider, just its parents
         super(PropSlider, self).__init__(parent)
         self._block = False
+        self._realtime_update = realtime_update
+        self._disable_scroll = disable_scroll
         self._slider = QDoubleSlider(decimals=decimals)
         self._spinbox = QtWidgets.QDoubleSpinBox()
         self._init()


### PR DESCRIPTION
Hey,
we are doing quite a bit with sliders, so we added additional options to them.

`realtime_update` emits value_changed events during dragging on the slider.
`disable_scroll` disables the ability to adjust values with the scroll wheel. This changes default behavior, but is really useful if one has enough properties for a scroll area to have a scroll bar. While scrolling over properties they would usually get changed accidentally.