### PR TITLE
pipe optimizations.

### DIFF
--- a/NodeGraphQt/constants.py
+++ b/NodeGraphQt/constants.py
@@ -164,7 +164,7 @@ class PipeEnum(Enum):
     #: default color.
     COLOR = (175, 95, 30, 255)
     #: pipe color to a node when it's disabled.
-    DISABLED_COLOR = (190, 20, 20, 255)
+    DISABLED_COLOR = (200, 60, 60, 255)
     #: pipe color when selected or mouse over.
     ACTIVE_COLOR = (70, 255, 220, 255)
     #: pipe color to a node when it's selected.

--- a/NodeGraphQt/nodes/base_node.py
+++ b/NodeGraphQt/nodes/base_node.py
@@ -86,11 +86,16 @@ class BaseNode(NodeObject):
             if self.graph:
                 undo_cmd = NodeVisibleCmd(self, value)
                 if push_undo:
-                    undo_stack = self.graph.undo_stack()
-                    undo_stack.push(undo_cmd)
+                    self.graph.undo_stack().push(undo_cmd)
                 else:
                     undo_cmd.redo()
                 return
+        elif name == 'disabled':
+            # redraw the connected pipes in the scene.
+            ports = self.view.inputs + self.view.outputs
+            for port in ports:
+                for pipe in port.connected_pipes:
+                    pipe.update()
         super(BaseNode, self).set_property(name, value, push_undo)
 
     def set_layout_direction(self, value=0):

--- a/NodeGraphQt/pkg_info.py
+++ b/NodeGraphQt/pkg_info.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
-__version__ = '0.5.11'
+__version__ = '0.5.12'
 __status__ = 'Work in Progress'
 __license__ = 'MIT'
 


### PR DESCRIPTION
- restored `Shift+LMB` on a pipe to start new live connection on ports that have multi connection enabled.
- more optimizations to the pipe drawing logic.

disabled pipe connections have a new look when highlighted.

![image](https://user-images.githubusercontent.com/7546915/237058688-0eed645e-86cc-48a4-a534-e3a8a2bc2b18.png)
