### PR TITLE
Pipe connection restriction #285

### DIFF
--- a/NodeGraphQt/base/graph.py
+++ b/NodeGraphQt/base/graph.py
@@ -160,6 +160,11 @@ class NodeGraph(QtCore.QObject):
             kwargs.get('viewer') or NodeViewer(undo_stack=self._undo_stack))
         self._viewer.set_layout_direction(layout_direction)
 
+        # viewer needs a reference to the model port connection constrains
+        # for the user interaction with the live pipe.
+        self._viewer.accept_connection_types = self._model.accept_connection_types
+        self._viewer.reject_connection_types = self._model.reject_connection_types
+
         self._context_menu = {}
 
         self._register_context_menu()
@@ -1143,6 +1148,39 @@ class NodeGraph(QtCore.QObject):
                     node_attrs[node.type_][pname].update(pattrs)
                 self.model.set_node_common_properties(node_attrs)
 
+            accept_types = node.model.__dict__.pop(
+                '_TEMP_accept_connection_types'
+            )
+            for ptype, pdata in accept_types.get(node.type_, {}).items():
+                for pname, accept_data in pdata.items():
+                    for accept_ntype, accept_ndata in accept_data.items():
+                        for accept_ptype, accept_pnames in accept_ndata.items():
+                            for accept_pname in accept_pnames:
+                                self._model.add_port_accept_connection_type(
+                                    port_name=pname,
+                                    port_type=ptype,
+                                    node_type=node.type_,
+                                    accept_pname=accept_pname,
+                                    accept_ptype=accept_ptype,
+                                    accept_ntype=accept_ntype
+                                )
+            reject_types = node.model.__dict__.pop(
+                '_TEMP_reject_connection_types'
+            )
+            for ptype, pdata in reject_types.get(node.type_, {}).items():
+                for pname, reject_data in pdata.items():
+                    for reject_ntype, reject_ndata in reject_data.items():
+                        for reject_ptype, reject_pnames in reject_ndata.items():
+                            for reject_pname in reject_pnames:
+                                self._model.add_port_reject_connection_type(
+                                    port_name=pname,
+                                    port_type=ptype,
+                                    node_type=node.type_,
+                                    reject_pname=reject_pname,
+                                    reject_ptype=reject_ptype,
+                                    reject_ntype=reject_ntype
+                                )
+
             node.NODE_NAME = self.get_unique_name(name or node.NODE_NAME)
             node.model.name = node.NODE_NAME
             node.model.selected = selected
@@ -1206,6 +1244,39 @@ class NodeGraph(QtCore.QObject):
             for pname, pattrs in prop_attrs.items():
                 node_attrs[node.type_][pname].update(pattrs)
             self.model.set_node_common_properties(node_attrs)
+
+        accept_types = node.model.__dict__.pop(
+            '_TEMP_accept_connection_types'
+        )
+        for ptype, pdata in accept_types.get(node.type_, {}).items():
+            for pname, accept_data in pdata.items():
+                for accept_ntype, accept_ndata in accept_data.items():
+                    for accept_ptype, accept_pnames in accept_ndata.items():
+                        for accept_pname in accept_pnames:
+                            self._model.add_port_accept_connection_type(
+                                port_name=pname,
+                                port_type=ptype,
+                                node_type=node.type_,
+                                accept_pname=accept_pname,
+                                accept_ptype=accept_ptype,
+                                accept_ntype=accept_ntype
+                            )
+        reject_types = node.model.__dict__.pop(
+            '_TEMP_reject_connection_types'
+        )
+        for ptype, pdata in reject_types.get(node.type_, {}).items():
+            for pname, reject_data in pdata.items():
+                for reject_ntype, reject_ndata in reject_data.items():
+                    for reject_ptype, reject_pnames in reject_ndata.items():
+                        for reject_pname in reject_pnames:
+                            self._model.add_port_reject_connection_type(
+                                port_name=pname,
+                                port_type=ptype,
+                                node_type=node.type_,
+                                reject_pname=reject_pname,
+                                reject_ptype=reject_ptype,
+                                reject_ntype=reject_ntype
+                            )
 
         node._graph = self
         node.NODE_NAME = self.get_unique_name(node.NODE_NAME)
@@ -1554,6 +1625,10 @@ class NodeGraph(QtCore.QObject):
         serial_data['graph']['pipe_collision'] = self.pipe_collision()
         serial_data['graph']['pipe_slicing'] = self.pipe_slicing()
 
+        # connection constrains.
+        serial_data['graph']['accept_connection_types'] = self.model.accept_connection_types
+        serial_data['graph']['reject_connection_types'] = self.model.reject_connection_types
+
         # serialize nodes.
         for n in nodes:
             # update the node model.
@@ -1617,6 +1692,12 @@ class NodeGraph(QtCore.QObject):
                 self.set_pipe_collision(attr_value)
             elif attr_name == 'pipe_slicing':
                 self.set_pipe_slicing(attr_value)
+
+            # connection constrains.
+            elif attr_name == 'accept_connection_types':
+                self.model.accept_connection_types = attr_value
+            elif attr_name == 'reject_connection_types':
+                self.model.reject_connection_types = attr_value
 
         # build the nodes.
         nodes = {}

--- a/NodeGraphQt/base/port.py
+++ b/NodeGraphQt/base/port.py
@@ -378,12 +378,14 @@ class Port(object):
             for cp in self.connected_ports():
                 self.disconnect_from(cp, push_undo=False)
 
-    def add_accept_port_type(self, port_name, port_type, port_node_type):
+    def add_accept_port_type(self, port_name, port_type, node_type):
         """
         Add a constrain to "accept" a pipe connection.
 
         Once a constrain has been added only ports of that type specified will
         be allowed a pipe connection.
+
+        `Implemented in` ``v0.6.0``
 
         See Also:
             :meth:`NodeGraphQt.Port.add_reject_ports_type`,
@@ -392,7 +394,7 @@ class Port(object):
         Args:
             port_name (str): name of the port.
             port_type (str): port type.
-            port_node_type (str): port node type.
+            node_type (str): port node type.
         """
         # storing the connection constrain at the graph level instead of the
         # port level so we don't serialize the same data for every port
@@ -402,7 +404,7 @@ class Port(object):
             port_type_data={
                 'port_name': port_name,
                 'port_type': port_type,
-                'node_type': port_node_type,
+                'node_type': node_type,
             }
         )
 
@@ -419,12 +421,14 @@ class Port(object):
         """
         return self.node().accepted_port_types(self)
 
-    def add_reject_port_type(self, port_name, port_type, port_node_type):
+    def add_reject_port_type(self, port_name, port_type, node_type):
         """
         Add a constrain to "reject" a pipe connection.
 
         Once a constrain has been added only ports of that type specified will
         be rejected a pipe connection.
+
+        `Implemented in` ``v0.6.0``
 
         See Also:
             :meth:`NodeGraphQt.Port.add_accept_ports_type`,
@@ -433,7 +437,7 @@ class Port(object):
         Args:
             port_name (str): name of the port.
             port_type (str): port type.
-            port_node_type (str): port node type.
+            node_type (str): port node type.
         """
         # storing the connection constrain at the graph level instead of the
         # port level so we don't serialize the same data for every port
@@ -443,7 +447,7 @@ class Port(object):
             port_type_data={
                 'port_name': port_name,
                 'port_type': port_type,
-                'node_type': port_node_type,
+                'node_type': node_type,
             }
         )
 

--- a/NodeGraphQt/nodes/base_node.py
+++ b/NodeGraphQt/nodes/base_node.py
@@ -657,6 +657,112 @@ class BaseNode(NodeObject):
             nodes[p] = [cp.node() for cp in p.connected_ports()]
         return nodes
 
+    def add_accept_port_type(self, port, port_type_data):
+        """
+        Add a accept constrain to a specified node port.
+
+        Once a constrain has been added only ports of that type specified will
+        be allowed a pipe connection.
+
+        Args:
+            port (NodeGraphQt.Port): port to assign constrain to.
+            port_type_data (dict): port type data to accept a connection
+                eg.
+                .. code-block:: python
+                    {
+                        'port_name': 'test 1'
+                        'port_type': PortTypeEnum.IN.value
+                        'node_type': 'io.github.jchanvfx.ExampleNode'
+                    }
+        """
+        node_ports = self._inputs + self._outputs
+        if port not in node_ports:
+            raise PortError('Node does not contain port: "{}"'.format(port))
+
+        self._model.add_port_accept_connection_type(
+            port_name=port.name(),
+            port_type=port.type_(),
+            node_type=self.type_,
+            accept_pname=port_type_data['port_name'],
+            accept_ptype=port_type_data['port_type'],
+            accept_ntype=port_type_data['node_type']
+        )
+
+    def accepted_port_types(self, port):
+        """
+        Returns a dictionary of connection constrains of the port types
+        that allow for a pipe connection to this node.
+
+        Args:
+            port (NodeGraphQt.Port): port object.
+
+        Returns:
+            dict: {<node_type>: {<port_type>: [<port_name>]}}
+        """
+        ports = self._inputs + self._outputs
+        if port not in ports:
+            raise PortError('Node does not contain port "{}"'.format(port))
+
+        accepted_types = self.graph.model.port_accept_connection_types(
+            node_type=self.type_,
+            port_type=port.type_(),
+            port_name=port.name()
+        )
+        return accepted_types
+
+    def add_reject_port_type(self, port, port_type_data):
+        """
+        Add a reject constrain to a specified node port.
+
+        Once a constrain has been added only ports of that type specified will
+        NOT be allowed a pipe connection.
+
+        Args:
+            port (NodeGraphQt.Port): port to assign constrain to.
+            port_type_data (dict): port type data to reject a connection
+                eg.
+                .. code-block:: python
+                    {
+                        'port_name': 'test 1'
+                        'port_type': PortTypeEnum.IN.value
+                        'node_type': 'io.github.jchanvfx.ExampleNode'
+                    }
+        """
+        node_ports = self._inputs + self._outputs
+        if port not in node_ports:
+            raise PortError('Node does not contain port: "{}"'.format(port))
+
+        self._model.add_port_reject_connection_type(
+            port_name=port.name(),
+            port_type=port.type_(),
+            node_type=self.type_,
+            reject_pname=port_type_data['port_name'],
+            reject_ptype=port_type_data['port_type'],
+            reject_ntype=port_type_data['node_type']
+        )
+
+    def rejected_port_types(self, port):
+        """
+        Returns a dictionary of connection constrains of the port types
+        that are NOT allowed for a pipe connection to this node.
+
+        Args:
+            port (NodeGraphQt.Port): port object.
+
+        Returns:
+            dict: {<node_type>: {<port_type>: [<port_name>]}}
+        """
+        ports = self._inputs + self._outputs
+        if port not in ports:
+            raise PortError('Node does not contain port "{}"'.format(port))
+
+        rejected_types = self.graph.model.port_reject_connection_types(
+            node_type=self.type_,
+            port_type=port.type_(),
+            port_name=port.name()
+        )
+        return rejected_types
+
     def on_input_connected(self, in_port, out_port):
         """
         Callback triggered when a new pipe connection is made.

--- a/NodeGraphQt/nodes/base_node.py
+++ b/NodeGraphQt/nodes/base_node.py
@@ -664,16 +664,22 @@ class BaseNode(NodeObject):
         Once a constrain has been added only ports of that type specified will
         be allowed a pipe connection.
 
+        port type data example
+
+        .. highlight:: python
+        .. code-block:: python
+            {
+                'port_name': 'foo'
+                'port_type': PortTypeEnum.IN.value
+                'node_type': 'io.github.jchanvfx.NodeClass'
+            }
+
+        See Also:
+            :meth:`NodeGraphQt.BaseNode.accepted_port_types`
+
         Args:
             port (NodeGraphQt.Port): port to assign constrain to.
             port_type_data (dict): port type data to accept a connection
-                eg.
-                .. code-block:: python
-                    {
-                        'port_name': 'test 1'
-                        'port_type': PortTypeEnum.IN.value
-                        'node_type': 'io.github.jchanvfx.ExampleNode'
-                    }
         """
         node_ports = self._inputs + self._outputs
         if port not in node_ports:
@@ -717,16 +723,22 @@ class BaseNode(NodeObject):
         Once a constrain has been added only ports of that type specified will
         NOT be allowed a pipe connection.
 
+        port type data example
+
+        .. highlight:: python
+        .. code-block:: python
+            {
+                'port_name': 'foo'
+                'port_type': PortTypeEnum.IN.value
+                'node_type': 'io.github.jchanvfx.NodeClass'
+            }
+
+        See Also:
+            :meth:`NodeGraphQt.Port.rejected_port_types`
+
         Args:
             port (NodeGraphQt.Port): port to assign constrain to.
             port_type_data (dict): port type data to reject a connection
-                eg.
-                .. code-block:: python
-                    {
-                        'port_name': 'test 1'
-                        'port_type': PortTypeEnum.IN.value
-                        'node_type': 'io.github.jchanvfx.ExampleNode'
-                    }
         """
         node_ports = self._inputs + self._outputs
         if port not in node_ports:

--- a/NodeGraphQt/pkg_info.py
+++ b/NodeGraphQt/pkg_info.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
-__version__ = '0.5.12'
+__version__ = '0.6.0'
 __status__ = 'Work in Progress'
 __license__ = 'MIT'
 

--- a/NodeGraphQt/qgraphics/node_base.py
+++ b/NodeGraphQt/qgraphics/node_base.py
@@ -761,15 +761,23 @@ class NodeItem(AbstractNodeItem):
         for w in self._widgets.values():
             w.widget().setVisible(visible)
 
+        # port text is not visible in vertical layout.
+        if self.layout_direction is LayoutDirectionEnum.VERTICAL.value:
+            port_text_visible = False
+        else:
+            port_text_visible = visible
+
         # input port text visibility.
         for port, text in self._input_items.items():
             if port.display_name:
-                text.setVisible(visible)
+                text.setVisible(port_text_visible)
 
         # output port text visibility.
         for port, text in self._output_items.items():
             if port.display_name:
-                text.setVisible(visible)
+                text.setVisible(port_text_visible)
+
+
 
         self._text_item.setVisible(visible)
         self._icon_item.setVisible(visible)

--- a/NodeGraphQt/qgraphics/pipe.py
+++ b/NodeGraphQt/qgraphics/pipe.py
@@ -583,8 +583,7 @@ class LivePipeItem(PipeItem):
         """
         QtWidgets.QGraphicsPathItem.hoverEnterEvent(self, event)
 
-    def draw_path(self, start_port, end_port=None, cursor_pos=None,
-                  color_mode=None):
+    def draw_path(self, start_port, end_port=None, cursor_pos=None, color=None):
         """
         re-implemented to also update the index pointer arrow position.
 
@@ -593,13 +592,12 @@ class LivePipeItem(PipeItem):
             end_port (PortItem): port used to draw the end point.
             cursor_pos (QtCore.QPointF): cursor position if specified this
                 will be the draw end point.
-            color_mode (str): arrow index pointer color mode
-                              ('accept', 'reject' or None).
+            color (list[int]): override arrow index pointer color. (r, g, b)
         """
         super(LivePipeItem, self).draw_path(start_port, end_port, cursor_pos)
-        self.draw_index_pointer(start_port, cursor_pos, color_mode)
+        self.draw_index_pointer(start_port, cursor_pos, color)
 
-    def draw_index_pointer(self, start_port, cursor_pos, color_mode=None):
+    def draw_index_pointer(self, start_port, cursor_pos, color=None):
         """
         Update the index pointer arrow position and direction when the
         live pipe path is redrawn.
@@ -607,8 +605,7 @@ class LivePipeItem(PipeItem):
         Args:
             start_port (PortItem): start port item.
             cursor_pos (QtCore.QPoint): cursor scene position.
-            color_mode (str): arrow index pointer color mode
-                              ('accept', 'reject' or None).
+            color (list[int]): override arrow index pointer color. (r, g, b).
         """
         text_rect = self._idx_text.boundingRect()
 
@@ -635,16 +632,13 @@ class LivePipeItem(PipeItem):
 
         self._idx_pointer.setPolygon(transform.map(self._poly))
 
-        if color_mode == 'accept':
-            color = QtGui.QColor(*PipeEnum.HIGHLIGHT_COLOR.value)
-        elif color_mode == 'reject':
-            color = QtGui.QColor(*PipeEnum.DISABLED_COLOR.value)
-        else:
-            color = QtGui.QColor(*PipeEnum.ACTIVE_COLOR.value)
+        pen_color = QtGui.QColor(*PipeEnum.HIGHLIGHT_COLOR.value)
+        if isinstance(color, (list, tuple)):
+            pen_color = QtGui.QColor(*color)
 
         pen = self._idx_pointer.pen()
-        pen.setColor(color)
-        self._idx_pointer.setBrush(color.darker(300))
+        pen.setColor(pen_color)
+        self._idx_pointer.setBrush(pen_color.darker(300))
         self._idx_pointer.setPen(pen)
 
 

--- a/NodeGraphQt/widgets/viewer.py
+++ b/NodeGraphQt/widgets/viewer.py
@@ -9,6 +9,7 @@ from NodeGraphQt.base.menu import BaseMenu
 from NodeGraphQt.constants import (
     LayoutDirectionEnum,
     PortTypeEnum,
+    PipeEnum,
     PipeLayoutEnum,
     ViewerEnum,
     Z_VAL_PIPE,
@@ -756,7 +757,7 @@ class NodeViewer(QtWidgets.QGraphicsView):
             return
 
         pos = event.scenePos()
-        color_mode = None
+        pointer_color = None
         for item in self.scene().items(pos):
             if not isinstance(item, PortItem):
                 continue
@@ -768,26 +769,25 @@ class NodeViewer(QtWidgets.QGraphicsView):
             pos.setY(pos.y() + y)
             if item == self._start_port:
                 break
-            color_mode = 'accept'
-
+            pointer_color = PipeEnum.HIGHLIGHT_COLOR.value
             accept = self._validate_accept_connection(self._start_port, item)
             if not accept:
-                color_mode = 'reject'
+                pointer_color = [150, 60, 255]
                 break
             reject = self._validate_reject_connection(self._start_port, item)
             if reject:
-                color_mode = 'reject'
+                pointer_color = [150, 60, 255]
                 break
 
             if self.acyclic:
                 if item.node == self._start_port.node:
-                    color_mode = 'reject'
+                    pointer_color = PipeEnum.DISABLED_COLOR.value
                 elif item.port_type == self._start_port.port_type:
-                    color_mode = 'reject'
+                    pointer_color = PipeEnum.DISABLED_COLOR.value
             break
 
         self._LIVE_PIPE.draw_path(
-            self._start_port, cursor_pos=pos, color_mode=color_mode
+            self._start_port, cursor_pos=pos, color=pointer_color
         )
 
     def sceneMousePressEvent(self, event):

--- a/docs/examples/ex_port.rst
+++ b/docs/examples/ex_port.rst
@@ -141,3 +141,68 @@ And here's another example function for drawing a Square port.
         painter.drawRect(rect)
 
         painter.restore()
+
+
+Connection Constrains
+*********************
+
+From version ``v0.6.0`` port object can now have pipe connection constraints the functions implemented are:
+
+:meth:`NodeGraphQt.Port.add_accept_ports_type` and :meth:`NodeGraphQt.Port.add_reject_ports_type`
+
+this can also be set on the ``BaseNode`` level as well with:
+:meth:`NodeGraphQt.BaseNode.add_accept_port_type`, :meth:`NodeGraphQt.BaseNode.add_accept_port_type`
+
+Here's an example snippet to add pipe connection constraints to a port.
+
+.. code-block:: python
+    :linenos:
+
+    from NodeGraphQt import BaseNode
+    from NodeGraphQt.constants import PortTypeEnum
+
+
+    class BasicNodeA(BaseNode):
+
+        # unique node identifier.
+        __identifier__ = 'io.github.jchanvfx'
+
+        # initial default node name.
+        NODE_NAME = 'node A'
+
+        def __init__(self):
+            super(BasicNode, self).__init__()
+
+            # create node output ports.
+            self.add_output('output 1')
+            self.add_output('output 2')
+
+
+    class BasicNodeB(BaseNode):
+
+        # unique node identifier.
+        __identifier__ = 'io.github.jchanvfx'
+
+        # initial default node name.
+        NODE_NAME = 'node B'
+
+        def __init__(self):
+            super(BasicNode, self).__init__()
+
+            # create node inputs.
+
+            # port "in A" will only accept pipe connections from port "output 1" under the node "BasicNodeA".
+            in_port_a = self.add_input('in A')
+            in_port_a.add_accept_port_type(
+                port_name='output 1',
+                port_type=PortTypeEnum.OUT.value,
+                node_type='io.github.jchanvfx.BasicNodeA'
+            )
+
+            # port "in A" will reject pipe connections from port "output 1" under the node "BasicNodeA".
+            in_port_b = self.add_input('in B')
+            in_port_b.add_reject_port_type(
+                port_name='output 1',
+                port_type=PortTypeEnum.OUT.value,
+                node_type='io.github.jchanvfx.BasicNodeA'
+            )


### PR DESCRIPTION
Implemented port constrain logic.

New functions.
- `NodeGraphQt.Port.add_accept_port_type`
- `NodeGraphQt.Port.add_reject_port_type`
- `NodeGraphQt.Port.accepted_port_types`
- `NodeGraphQt.Port.rejected_port_types`
- `NodeGraphQt.BaseNode.add_accept_port_type`
- `NodeGraphQt.BaseNode.add_reject_port_type`
- `NodeGraphQt.BaseNode.accepted_port_types`
- `NodeGraphQt.BaseNode.rejected_port_types`