### PR TITLE
implement `context_menu_prompt` signal.

### DIFF
--- a/NodeGraphQt/base/graph.py
+++ b/NodeGraphQt/base/graph.py
@@ -122,8 +122,17 @@ class NodeGraph(QtCore.QObject):
     """
     Signal is triggered when session has been changed.
 
-    :parameters: :str
+    :parameters: str
     :emits: new session path
+    """
+    context_menu_prompt = QtCore.Signal(object, object)
+    """
+    Signal is triggered just before a context menu is shown.
+
+    :parameters: 
+        :class:`NodeGraphQt.NodeGraphMenu` or :class:`NodeGraphQt.NodesMenu`, 
+        :class:`NodeGraphQt.BaseNode`
+    :emits: triggered context menu, node object.
     """
 
     def __init__(self, parent=None, **kwargs):
@@ -220,6 +229,19 @@ class NodeGraph(QtCore.QObject):
         self._viewer.node_selection_changed.connect(
             self._on_node_selection_changed)
         self._viewer.data_dropped.connect(self._on_node_data_dropped)
+        self._viewer.context_menu_prompt.connect(self._on_context_menu_prompt)
+
+    def _on_context_menu_prompt(self, menu_name, node_id):
+        """
+        Slot function triggered just before a context menu is shown.
+
+        Args:
+            menu_name (str): context menu name.
+            node_id (str): node id if triggered from the nodes context menu.
+        """
+        node = self.get_node_by_id(node_id)
+        menu = self.get_context_menu(menu_name)
+        self.context_menu_prompt.emit(menu, node)
 
     def _on_insert_node(self, pipe, node_id, prev_node_pos):
         """

--- a/NodeGraphQt/base/menu.py
+++ b/NodeGraphQt/base/menu.py
@@ -294,3 +294,15 @@ class NodeGraphCommand(object):
         execute the menu command.
         """
         self.qaction.trigger()
+
+    def show(self):
+        """
+        Set the command to be visible in the context menu.
+        """
+        self.qaction.setVisible(True)
+
+    def hide(self):
+        """
+        Set the command to be hidden in the context menu.
+        """
+        self.qaction.setVisible(False)

--- a/NodeGraphQt/pkg_info.py
+++ b/NodeGraphQt/pkg_info.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
-__version__ = '0.6.4'
+__version__ = '0.6.5'
 __status__ = 'Work in Progress'
 __license__ = 'MIT'
 

--- a/NodeGraphQt/widgets/viewer.py
+++ b/NodeGraphQt/widgets/viewer.py
@@ -51,6 +51,7 @@ class NodeViewer(QtWidgets.QGraphicsView):
     node_selection_changed = QtCore.Signal(list, list)
     node_double_clicked = QtCore.Signal(str)
     data_dropped = QtCore.Signal(QtCore.QMimeData, QtCore.QPoint)
+    context_menu_prompt = QtCore.Signal(str, object)
 
     def __init__(self, parent=None, undo_stack=None):
         """
@@ -354,6 +355,8 @@ class NodeViewer(QtWidgets.QGraphicsView):
         ctx_menu = None
         ctx_menus = self.context_menus()
 
+        prompted_data = None, None
+
         if ctx_menus['nodes'].isEnabled():
             pos = self.mapToScene(self._previous_pos)
             items = self._items_near(pos)
@@ -365,10 +368,17 @@ class NodeViewer(QtWidgets.QGraphicsView):
                     for action in ctx_menu.actions():
                         if not action.menu():
                             action.node_id = node.id
+                    prompted_data = 'nodes', node.id
 
-        ctx_menu = ctx_menu or ctx_menus['graph']
+        if not ctx_menu:
+            ctx_menu = ctx_menus['graph']
+            prompted_data = 'graph', None
+
         if len(ctx_menu.actions()) > 0:
             if ctx_menu.isEnabled():
+                self.context_menu_prompt.emit(
+                    prompted_data[0], prompted_data[1]
+                )
                 ctx_menu.exec_(event.globalPos())
             else:
                 return super(NodeViewer, self).contextMenuEvent(event)


### PR DESCRIPTION
- added a new `context_menu_prompt` signal that is triggered just before the context menu is shown. 
- added convivence functions to show and hide commands.
- requests from #351