### PR TITLE
Serialize session bugfix #363

### DIFF
--- a/NodeGraphQt/base/model.py
+++ b/NodeGraphQt/base/model.py
@@ -537,9 +537,9 @@ class NodeGraphModel(object):
             connection_data = connection_data[key]
 
         if accept_ptype not in connection_data:
-            connection_data[accept_ptype] = set([accept_pname])
+            connection_data[accept_ptype] = [accept_pname]
         else:
-            connection_data[accept_ptype].add(accept_pname)
+            connection_data[accept_ptype].append(accept_pname)
 
     def port_accept_connection_types(self, node_type, port_type, port_name):
         """
@@ -582,9 +582,9 @@ class NodeGraphModel(object):
             connection_data = connection_data[key]
 
         if reject_ptype not in connection_data:
-            connection_data[reject_ptype] = set([reject_pname])
+            connection_data[reject_ptype] = [reject_pname]
         else:
-            connection_data[reject_ptype].add(reject_pname)
+            connection_data[reject_ptype].append(reject_pname)
 
     def port_reject_connection_types(self, node_type, port_type, port_name):
         """

--- a/NodeGraphQt/pkg_info.py
+++ b/NodeGraphQt/pkg_info.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
-__version__ = '0.6.11'
+__version__ = '0.6.12'
 __status__ = 'Work in Progress'
 __license__ = 'MIT'
 

--- a/examples/hotkeys/hotkey_functions.py
+++ b/examples/hotkeys/hotkey_functions.py
@@ -86,7 +86,7 @@ def save_session_as(graph):
         graph.save_session(file_path)
 
 
-def new_session(graph):
+def clear_session(graph):
     """
     Prompts a warning dialog to new a node graph session.
     """

--- a/examples/hotkeys/hotkeys.json
+++ b/examples/hotkeys/hotkeys.json
@@ -19,6 +19,13 @@
       },
       {
         "type":"command",
+        "label":"Clear Session...",
+        "file":"../examples/hotkeys/hotkey_functions.py",
+        "function_name":"clear_session",
+        "shortcut":""
+      },
+      {
+        "type":"command",
         "label":"Save...",
         "file":"../examples/hotkeys/hotkey_functions.py",
         "function_name":"save_session",


### PR DESCRIPTION
bugfix to connection constrain functions using `set` instead of `list` causing the serialization to fail.