### PR TITLE
Rebase #327 and continue migration to PySide6/PyQt6 using qtpy compat layer

### DIFF
--- a/NodeGraphQt/base/commands.py
+++ b/NodeGraphQt/base/commands.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-from Qt import QtWidgets
+from qtpy import QtWidgets
 
 from NodeGraphQt.constants import PortTypeEnum
 

--- a/NodeGraphQt/base/graph.py
+++ b/NodeGraphQt/base/graph.py
@@ -5,7 +5,7 @@ import json
 import os
 import re
 
-from qtpy import QtCore, QtWidgets
+from qtpy import QtCore, QtWidgets, QtGui
 
 from NodeGraphQt.base.commands import (NodeAddedCmd,
                                        NodesRemovedCmd,
@@ -150,7 +150,7 @@ class NodeGraph(QtCore.QObject):
             kwargs.get('node_factory') or NodeFactory())
         self._undo_view = None
         self._undo_stack = (
-            kwargs.get('undo_stack') or QtWidgets.QUndoStack(self)
+            kwargs.get('undo_stack') or QtGui.QUndoStack(self)
         )
         self._widget = None
         self._sub_graphs = {}
@@ -519,7 +519,7 @@ class NodeGraph(QtCore.QObject):
             self._widget.addTab(self._viewer, 'Node Graph')
             # hide the close button on the first tab.
             tab_bar = self._widget.tabBar()
-            for btn_flag in [tab_bar.RightSide, tab_bar.LeftSide]:
+            for btn_flag in [tab_bar.ButtonPosition.RightSide, tab_bar.ButtonPosition.LeftSide]:
                 tab_btn = tab_bar.tabButton(0, btn_flag)
                 if tab_btn:
                     tab_btn.deleteLater()

--- a/NodeGraphQt/base/graph.py
+++ b/NodeGraphQt/base/graph.py
@@ -5,7 +5,7 @@ import json
 import os
 import re
 
-from Qt import QtCore, QtWidgets
+from qtpy import QtCore, QtWidgets
 
 from NodeGraphQt.base.commands import (NodeAddedCmd,
                                        NodesRemovedCmd,

--- a/NodeGraphQt/base/menu.py
+++ b/NodeGraphQt/base/menu.py
@@ -2,7 +2,7 @@
 import re
 from distutils.version import LooseVersion
 
-from Qt import QtGui, QtCore
+from qtpy import QtGui, QtCore
 
 from NodeGraphQt.errors import NodeMenuError
 from NodeGraphQt.widgets.actions import BaseMenu, GraphAction, NodeAction

--- a/NodeGraphQt/base/menu.py
+++ b/NodeGraphQt/base/menu.py
@@ -120,10 +120,10 @@ class NodeGraphMenu(object):
                 shortcut = getattr(QtGui.QKeySequence, search.group(1))
             elif all([i in ['Alt', 'Enter'] for i in shortcut.split('+')]):
                 shortcut = QtGui.QKeySequence(
-                    QtCore.Qt.ALT + QtCore.Qt.Key_Return
+                    QtCore.Qt.Modifier.ALT | QtCore.Qt.Key.Key_Return
                 )
             elif all([i in ['Return', 'Enter'] for i in shortcut.split('+')]):
-                shortcut = QtCore.Qt.Key_Return
+                shortcut = QtCore.Qt.Key.Key_Return
         if shortcut:
             action.setShortcut(shortcut)
 

--- a/NodeGraphQt/constants.py
+++ b/NodeGraphQt/constants.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 import os
 
-from Qt import QtWidgets
+from qtpy import QtWidgets
 from enum import Enum
 
 from .pkg_info import __version__ as _v

--- a/NodeGraphQt/custom_widgets/nodes_palette.py
+++ b/NodeGraphQt/custom_widgets/nodes_palette.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 from collections import defaultdict
 
-from Qt import QtWidgets, QtCore, QtGui
+from qtpy import QtWidgets, QtCore, QtGui
 
 from NodeGraphQt.constants import MIME_TYPE, URN_SCHEME
 

--- a/NodeGraphQt/custom_widgets/nodes_palette.py
+++ b/NodeGraphQt/custom_widgets/nodes_palette.py
@@ -34,7 +34,7 @@ class _NodesGridDelegate(QtWidgets.QStyledItemDelegate):
         )
 
         painter.save()
-        painter.setRenderHint(QtGui.QPainter.Antialiasing, True)
+        painter.setRenderHint(QtGui.QPainter.RenderHint.Antialiasing, True)
 
         # background.
         bg_color = option.palette.window().color()
@@ -44,21 +44,21 @@ class _NodesGridDelegate(QtWidgets.QStyledItemDelegate):
             pen_color = pen_color.lighter(160)
 
         pen = QtGui.QPen(pen_color, 3.0)
-        pen.setCapStyle(QtCore.Qt.RoundCap)
+        pen.setCapStyle(QtCore.Qt.PenCapStyle.RoundCap)
         painter.setPen(pen)
         painter.setBrush(QtGui.QBrush(bg_color))
         painter.drawRoundedRect(base_rect,
                               int(base_rect.height()/radius),
                               int(base_rect.width()/radius))
 
-        if option.state & QtWidgets.QStyle.State_Selected:
+        if option.state & QtWidgets.QStyle.StateFlag.State_Selected:
             pen_color = option.palette.highlight().color()
         else:
             pen_color = option.palette.midlight().color().darker(130)
         pen = QtGui.QPen(pen_color, 1.0)
-        pen.setCapStyle(QtCore.Qt.RoundCap)
+        pen.setCapStyle(QtCore.Qt.PenCapStyle.RoundCap)
         painter.setPen(pen)
-        painter.setBrush(QtCore.Qt.NoBrush)
+        painter.setBrush(QtCore.Qt.BrushStyle.NoBrush)
 
         sub_margin = 6
         sub_rect = QtCore.QRectF(
@@ -97,7 +97,7 @@ class _NodesGridDelegate(QtWidgets.QStyledItemDelegate):
         # text
         pen_color = option.palette.text().color()
         pen = QtGui.QPen(pen_color, 0.5)
-        pen.setCapStyle(QtCore.Qt.RoundCap)
+        pen.setCapStyle(QtCore.Qt.PenCapStyle.RoundCap)
         painter.setPen(pen)
 
         font = painter.font()
@@ -123,7 +123,7 @@ class _NodesGridProxyModel(QtCore.QSortFilterProxyModel):
         
     def mimeData(self, indexes, p_int=None):
         node_ids = [
-            'node:{}'.format(i.data(QtCore.Qt.ToolTipRole))
+            'node:{}'.format(i.data(QtCore.Qt.ItemDataRole.ToolTipRole))
             for i in indexes
         ]
         node_urn = URN_SCHEME + ';'.join(node_ids)
@@ -136,11 +136,11 @@ class NodesGridView(QtWidgets.QListView):
 
     def __init__(self, parent=None):
         super(NodesGridView, self).__init__(parent)
-        self.setSelectionMode(self.ExtendedSelection)
+        self.setSelectionMode(self.SelectionMode.ExtendedSelection)
         self.setUniformItemSizes(True)
-        self.setResizeMode(self.Adjust)
-        self.setViewMode(self.IconMode)
-        self.setDragDropMode(self.DragOnly)
+        self.setResizeMode(self.ResizeMode.Adjust)
+        self.setViewMode(self.ViewMode.IconMode)
+        self.setDragDropMode(self.DragDropMode.DragOnly)
         self.setDragEnabled(True)
         self.setMinimumSize(300, 100)
         self.setSpacing(4)

--- a/NodeGraphQt/custom_widgets/nodes_tree.py
+++ b/NodeGraphQt/custom_widgets/nodes_tree.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
-from Qt import QtWidgets, QtCore, QtGui
+from qtpy import QtWidgets, QtCore, QtGui
 
 from NodeGraphQt.constants import MIME_TYPE, URN_SCHEME
 

--- a/NodeGraphQt/custom_widgets/nodes_tree.py
+++ b/NodeGraphQt/custom_widgets/nodes_tree.py
@@ -50,8 +50,8 @@ class NodesTreeWidget(QtWidgets.QTreeWidget):
 
     def __init__(self, parent=None, node_graph=None):
         super(NodesTreeWidget, self).__init__(parent)
-        self.setDragDropMode(QtWidgets.QAbstractItemView.DragOnly)
-        self.setSelectionMode(self.ExtendedSelection)
+        self.setDragDropMode(QtWidgets.QAbstractItemView.DragDropMode.DragOnly)
+        self.setSelectionMode(self.SelectionMode.ExtendedSelection)
         self.setHeaderHidden(True)
         self.setWindowTitle('Nodes')
 
@@ -93,7 +93,7 @@ class NodesTreeWidget(QtWidgets.QTreeWidget):
                 label = '{}'.format(category)
             cat_item = _BaseNodeTreeItem(self, [label], type=TYPE_CATEGORY)
             cat_item.setFirstColumnSpanned(True)
-            cat_item.setFlags(QtCore.Qt.ItemIsEnabled)
+            cat_item.setFlags(QtCore.Qt.ItemFlag.ItemIsEnabled)
             cat_item.setSizeHint(0, QtCore.QSize(100, 26))
             self.addTopLevelItem(cat_item)
             cat_item.setExpanded(True)

--- a/NodeGraphQt/custom_widgets/properties_bin/custom_widget_color_picker.py
+++ b/NodeGraphQt/custom_widgets/properties_bin/custom_widget_color_picker.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-from Qt import QtWidgets, QtCore, QtGui
+from qtpy import QtWidgets, QtCore, QtGui
 
 from .custom_widget_vectors import PropVector3, PropVector4
 from .prop_widgets_abstract import BaseProperty

--- a/NodeGraphQt/custom_widgets/properties_bin/custom_widget_color_picker.py
+++ b/NodeGraphQt/custom_widgets/properties_bin/custom_widget_color_picker.py
@@ -27,8 +27,8 @@ class PropColorPickerRGB(BaseProperty):
 
         layout = QtWidgets.QHBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
-        layout.addWidget(self._button, 0, QtCore.Qt.AlignLeft)
-        layout.addWidget(self._vector, 1, QtCore.Qt.AlignLeft)
+        layout.addWidget(self._button, 0, QtCore.Qt.AlignmentFlag.AlignLeft)
+        layout.addWidget(self._vector, 1, QtCore.Qt.AlignmentFlag.AlignLeft)
 
     def _on_vector_changed(self, _, value):
         self._color = tuple(value)
@@ -99,8 +99,8 @@ class PropColorPickerRGBA(PropColorPickerRGB):
 
         layout = QtWidgets.QHBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
-        layout.addWidget(self._button, 0, QtCore.Qt.AlignLeft)
-        layout.addWidget(self._vector, 1, QtCore.Qt.AlignLeft)
+        layout.addWidget(self._button, 0, QtCore.Qt.AlignmentFlag.AlignLeft)
+        layout.addWidget(self._vector, 1, QtCore.Qt.AlignmentFlag.AlignLeft)
 
     def _update_color(self):
         c = [int(max(min(i, 255), 0)) for i in self._color]

--- a/NodeGraphQt/custom_widgets/properties_bin/custom_widget_file_paths.py
+++ b/NodeGraphQt/custom_widgets/properties_bin/custom_widget_file_paths.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-from Qt import QtWidgets, QtCore
+from qtpy import QtWidgets, QtCore
 
 from NodeGraphQt.widgets.dialogs import FileDialog
 from .prop_widgets_abstract import BaseProperty

--- a/NodeGraphQt/custom_widgets/properties_bin/custom_widget_file_paths.py
+++ b/NodeGraphQt/custom_widgets/properties_bin/custom_widget_file_paths.py
@@ -14,7 +14,7 @@ class PropFilePath(BaseProperty):
     def __init__(self, parent=None):
         super(PropFilePath, self).__init__(parent)
         self._ledit = QtWidgets.QLineEdit()
-        self._ledit.setAlignment(QtCore.Qt.AlignLeft)
+        self._ledit.setAlignment(QtCore.Qt.AlignmentFlag.AlignLeft)
         self._ledit.editingFinished.connect(self._on_value_change)
         self._ledit.clearFocus()
 

--- a/NodeGraphQt/custom_widgets/properties_bin/custom_widget_slider.py
+++ b/NodeGraphQt/custom_widgets/properties_bin/custom_widget_slider.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-from Qt import QtWidgets, QtCore
+from qtpy import QtWidgets, QtCore
 
 from .prop_widgets_abstract import BaseProperty
 

--- a/NodeGraphQt/custom_widgets/properties_bin/custom_widget_slider.py
+++ b/NodeGraphQt/custom_widgets/properties_bin/custom_widget_slider.py
@@ -21,11 +21,11 @@ class PropSlider(BaseProperty):
         self._init_signal_connections()
 
     def _init(self):
-        self._slider.setOrientation(QtCore.Qt.Horizontal)
-        self._slider.setTickPosition(QtWidgets.QSlider.TicksBelow)
-        self._slider.setSizePolicy(QtWidgets.QSizePolicy.Expanding,
-                                   QtWidgets.QSizePolicy.Preferred)
-        self._spinbox.setButtonSymbols(QtWidgets.QAbstractSpinBox.NoButtons)
+        self._slider.setOrientation(QtCore.Qt.Orientation.Horizontal)
+        self._slider.setTickPosition(QtWidgets.QSlider.TickPosition.TicksBelow)
+        self._slider.setSizePolicy(QtWidgets.QSizePolicy.Policy.Expanding,
+                                   QtWidgets.QSizePolicy.Policy.Preferred)
+        self._spinbox.setButtonSymbols(QtWidgets.QAbstractSpinBox.ButtonSymbols.NoButtons)
         layout = QtWidgets.QHBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
         layout.addWidget(self._spinbox)

--- a/NodeGraphQt/custom_widgets/properties_bin/custom_widget_value_edit.py
+++ b/NodeGraphQt/custom_widgets/properties_bin/custom_widget_value_edit.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 import re
 
-from Qt import QtWidgets, QtCore, QtGui
+from qtpy import QtWidgets, QtCore, QtGui
 
 _NUMB_REGEX = re.compile(r'^((?:\-)*\d+)*([\.,])*(\d+(?:[eE](?:[\-\+])*\d+)*)*')
 

--- a/NodeGraphQt/custom_widgets/properties_bin/custom_widget_value_edit.py
+++ b/NodeGraphQt/custom_widgets/properties_bin/custom_widget_value_edit.py
@@ -192,14 +192,14 @@ class _NumberValueEdit(QtWidgets.QLineEdit):
         """
         self._data_type = data_type
         if data_type is int:
-            regexp = QtCore.QRegExp(r'\d+')
-            validator = QtGui.QRegExpValidator(regexp, self)
+            regexp = QtCore.QRegularExpression(r'\d+')
+            validator = QtGui.QRegularExpressionValidator(regexp, self)
             steps = [1, 10, 100, 1000]
             self._min = None if self._min is None else int(self._min)
             self._max = None if self._max is None else int(self._max)
         elif data_type is float:
-            regexp = QtCore.QRegExp(r'\d+[\.,]\d+(?:[eE](?:[\-\+]|)\d+)*')
-            validator = QtGui.QRegExpValidator(regexp, self)
+            regexp = QtCore.QRegularExpression(r'\d+[\.,]\d+(?:[eE](?:[\-\+]|)\d+)*')
+            validator = QtGui.QRegularExpressionValidator(regexp, self)
             steps = [0.001, 0.01, 0.1, 1]
             self._min = None if self._min is None else float(self._min)
             self._max = None if self._max is None else float(self._max)

--- a/NodeGraphQt/custom_widgets/properties_bin/custom_widget_value_edit.py
+++ b/NodeGraphQt/custom_widgets/properties_bin/custom_widget_value_edit.py
@@ -122,7 +122,7 @@ class _NumberValueEdit(QtWidgets.QLineEdit):
         super(_NumberValueEdit, self).mouseMoveEvent(event)
 
     def mousePressEvent(self, event):
-        if event.button() == QtCore.Qt.MiddleButton:
+        if event.button() == QtCore.Qt.MouseButton.MiddleButton:
             self._MMB_STATE = True
             self._reset_previous_x()
             self._menu.exec_(QtGui.QCursor.pos())
@@ -135,9 +135,9 @@ class _NumberValueEdit(QtWidgets.QLineEdit):
 
     def keyPressEvent(self, event):
         super(_NumberValueEdit, self).keyPressEvent(event)
-        if event.key() == QtCore.Qt.Key_Up:
+        if event.key() == QtCore.Qt.Key.Key_Up:
             return
-        elif event.key() == QtCore.Qt.Key_Down:
+        elif event.key() == QtCore.Qt.Key.Key_Down:
             return
 
     # private

--- a/NodeGraphQt/custom_widgets/properties_bin/custom_widget_vectors.py
+++ b/NodeGraphQt/custom_widgets/properties_bin/custom_widget_vectors.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-from Qt import QtWidgets
+from qtpy import QtWidgets
 
 from .custom_widget_value_edit import _NumberValueEdit
 from .prop_widgets_abstract import BaseProperty

--- a/NodeGraphQt/custom_widgets/properties_bin/node_property_widgets.py
+++ b/NodeGraphQt/custom_widgets/properties_bin/node_property_widgets.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 from collections import defaultdict
 
-from Qt import QtWidgets, QtCore, QtGui, QtCompat
+from qtpy import QtWidgets, QtCore, QtGui, QtCompat
 
 from .node_property_factory import NodePropertyWidgetFactory
 from .prop_widgets_base import PropLineEdit

--- a/NodeGraphQt/custom_widgets/properties_bin/node_property_widgets.py
+++ b/NodeGraphQt/custom_widgets/properties_bin/node_property_widgets.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 from collections import defaultdict
 
-from qtpy import QtWidgets, QtCore, QtGui, QtCompat
+from qtpy import QtWidgets, QtCore, QtGui
 
 from .node_property_factory import NodePropertyWidgetFactory
 from .prop_widgets_base import PropLineEdit
@@ -54,13 +54,13 @@ class _PropertiesList(QtWidgets.QTableWidget):
         self.verticalHeader().hide()
         self.horizontalHeader().hide()
 
-        QtCompat.QHeaderView.setSectionResizeMode(
-            self.verticalHeader(), QtWidgets.QHeaderView.ResizeToContents
+        QtWidgets.QHeaderView.setSectionResizeMode(
+            self.verticalHeader(), QtWidgets.QHeaderView.ResizeMode.ResizeToContents
         )
-        QtCompat.QHeaderView.setSectionResizeMode(
-            self.horizontalHeader(), 0, QtWidgets.QHeaderView.Stretch
+        QtWidgets.QHeaderView.setSectionResizeMode(
+            self.horizontalHeader(), 0, QtWidgets.QHeaderView.ResizeMode.Stretch
         )
-        self.setVerticalScrollMode(QtWidgets.QAbstractItemView.ScrollPerPixel)
+        self.setVerticalScrollMode(QtWidgets.QAbstractItemView.ScrollMode.ScrollPerPixel)
 
     def wheelEvent(self, event):
         """
@@ -120,9 +120,9 @@ class _PropertiesContainer(QtWidgets.QWidget):
         if row > 0:
             row += 1
 
-        label_flags = QtCore.Qt.AlignCenter | QtCore.Qt.AlignRight
+        label_flags = QtCore.Qt.AlignmentFlag.AlignCenter | QtCore.Qt.AlignmentFlag.AlignRight
         if widget.__class__.__name__ == 'PropTextEdit':
-            label_flags = label_flags | QtCore.Qt.AlignTop
+            label_flags = label_flags | QtCore.Qt.AlignmentFlag.AlignTop
 
         self.__layout.addWidget(label_widget, row, 0, label_flags)
         self.__layout.addWidget(widget, row, 1)
@@ -317,7 +317,7 @@ class NodePropEditorWidget(QtWidgets.QWidget):
         close_btn = QtWidgets.QPushButton()
         close_btn.setIcon(QtGui.QIcon(
             self.style().standardPixmap(
-                QtWidgets.QStyle.SP_DialogCloseButton
+                QtWidgets.QStyle.StandardPixmap.SP_DialogCloseButton
             )
         ))
         close_btn.setMaximumWidth(40)
@@ -331,7 +331,7 @@ class NodePropEditorWidget(QtWidgets.QWidget):
         self.name_wgt.value_changed.connect(self._on_property_changed)
 
         self.type_wgt = QtWidgets.QLabel(node.type_)
-        self.type_wgt.setAlignment(QtCore.Qt.AlignRight)
+        self.type_wgt.setAlignment(QtCore.Qt.AlignmentFlag.AlignRight)
         self.type_wgt.setToolTip(
             'type_\nNode type identifier followed by the class name.'
         )
@@ -701,7 +701,7 @@ class PropertiesBinWidget(QtWidgets.QWidget):
         Args:
             node_id (str): node id.
         """
-        items = self._prop_list.findItems(node_id, QtCore.Qt.MatchExactly)
+        items = self._prop_list.findItems(node_id, QtCore.Qt.MatchFlag.MatchExactly)
         [self._prop_list.removeRow(i.row()) for i in items]
 
     def __on_limit_changed(self, value):
@@ -802,7 +802,7 @@ class PropertiesBinWidget(QtWidgets.QWidget):
         if rows >= self.limit():
             self._prop_list.removeRow(rows - 1)
 
-        itm_find = self._prop_list.findItems(node.id, QtCore.Qt.MatchExactly)
+        itm_find = self._prop_list.findItems(node.id, QtCore.Qt.MatchFlag.MatchExactly)
         if itm_find:
             self._prop_list.removeRow(itm_find[0].row())
 
@@ -867,7 +867,7 @@ class PropertiesBinWidget(QtWidgets.QWidget):
             NodePropEditorWidget: node property editor widget.
         """
         node_id = node if isinstance(node, str) else node.id
-        itm_find = self._prop_list.findItems(node_id, QtCore.Qt.MatchExactly)
+        itm_find = self._prop_list.findItems(node_id, QtCore.Qt.MatchFlag.MatchExactly)
         if itm_find:
             item = itm_find[0]
             return self._prop_list.cellWidget(item.row(), 0)

--- a/NodeGraphQt/custom_widgets/properties_bin/node_property_widgets.py
+++ b/NodeGraphQt/custom_widgets/properties_bin/node_property_widgets.py
@@ -17,7 +17,7 @@ class _PropertiesDelegate(QtWidgets.QStyledItemDelegate):
             index (QtCore.QModelIndex):
         """
         painter.save()
-        painter.setRenderHint(QtGui.QPainter.Antialiasing, False)
+        painter.setRenderHint(QtGui.QPainter.RenderHint.Antialiasing, False)
         painter.setPen(QtCore.Qt.NoPen)
 
         # draw background.
@@ -218,7 +218,7 @@ class _PortConnectionsContainer(QtWidgets.QWidget):
         tree_widget.setHeaderLabels(headers)
         tree_widget.setHeaderHidden(False)
         tree_widget.header().setStretchLastSection(False)
-        QtCompat.QHeaderView.setSectionResizeMode(
+        QtWidgets.QHeaderView.setSectionResizeMode(
             tree_widget.header(), 2, QtWidgets.QHeaderView.Stretch
         )
 
@@ -688,7 +688,7 @@ class PropertiesBinWidget(QtWidgets.QWidget):
             tree_widget.setVisible(visible)
             widget = self._prop_list.cellWidget(items[0].row(), 0)
             widget.adjustSize()
-            QtCompat.QHeaderView.setSectionResizeMode(
+            QtWidgets.QHeaderView.setSectionResizeMode(
                 self._prop_list.verticalHeader(),
                 QtWidgets.QHeaderView.ResizeToContents
             )

--- a/NodeGraphQt/custom_widgets/properties_bin/prop_widgets_abstract.py
+++ b/NodeGraphQt/custom_widgets/properties_bin/prop_widgets_abstract.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-from Qt import QtWidgets, QtCore
+from qtpy import QtWidgets, QtCore
 
 
 class BaseProperty(QtWidgets.QWidget):

--- a/NodeGraphQt/custom_widgets/properties_bin/prop_widgets_base.py
+++ b/NodeGraphQt/custom_widgets/properties_bin/prop_widgets_base.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-from Qt import QtWidgets, QtCore
+from qtpy import QtWidgets, QtCore
 
 
 class PropLabel(QtWidgets.QLabel):

--- a/NodeGraphQt/custom_widgets/properties_bin/prop_widgets_base.py
+++ b/NodeGraphQt/custom_widgets/properties_bin/prop_widgets_base.py
@@ -161,7 +161,7 @@ class PropComboBox(QtWidgets.QComboBox):
 
     def set_value(self, value):
         if value != self.get_value():
-            idx = self.findText(value, QtCore.Qt.MatchExactly)
+            idx = self.findText(value, QtCore.Qt.MatchFlag.MatchExactly)
             self.setCurrentIndex(idx)
             if idx >= 0:
                 self.value_changed.emit(self.get_name(), value)
@@ -213,7 +213,7 @@ class PropSpinBox(QtWidgets.QSpinBox):
     def __init__(self, parent=None):
         super(PropSpinBox, self).__init__(parent)
         self._name = None
-        self.setButtonSymbols(self.NoButtons)
+        self.setButtonSymbols(self.ButtonSymbols.NoButtons)
         self.valueChanged.connect(self._on_value_change)
 
     def __repr__(self):
@@ -248,7 +248,7 @@ class PropDoubleSpinBox(QtWidgets.QDoubleSpinBox):
     def __init__(self, parent=None):
         super(PropDoubleSpinBox, self).__init__(parent)
         self._name = None
-        self.setButtonSymbols(self.NoButtons)
+        self.setButtonSymbols(self.ButtonSymbols.NoButtons)
         self.valueChanged.connect(self._on_value_change)
 
     def __repr__(self):

--- a/NodeGraphQt/qgraphics/node_abstract.py
+++ b/NodeGraphQt/qgraphics/node_abstract.py
@@ -16,7 +16,7 @@ class AbstractNodeItem(QtWidgets.QGraphicsItem):
 
     def __init__(self, name='node', parent=None):
         super(AbstractNodeItem, self).__init__(parent)
-        self.setFlags(self.ItemIsSelectable | self.ItemIsMovable)
+        self.setFlags(self.GraphicsItemFlag.ItemIsSelectable | self.GraphicsItemFlag.ItemIsMovable)
         self.setCacheMode(ITEM_CACHE_MODE)
         self.setZValue(Z_VAL_NODE)
         self._properties = {

--- a/NodeGraphQt/qgraphics/node_abstract.py
+++ b/NodeGraphQt/qgraphics/node_abstract.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-from Qt import QtCore, QtWidgets
+from qtpy import QtCore, QtWidgets
 
 from NodeGraphQt.constants import (
     Z_VAL_NODE,

--- a/NodeGraphQt/qgraphics/node_backdrop.py
+++ b/NodeGraphQt/qgraphics/node_backdrop.py
@@ -18,10 +18,10 @@ class BackdropSizer(QtWidgets.QGraphicsItem):
 
     def __init__(self, parent=None, size=6.0):
         super(BackdropSizer, self).__init__(parent)
-        self.setFlag(self.ItemIsSelectable, True)
-        self.setFlag(self.ItemIsMovable, True)
-        self.setFlag(self.ItemSendsScenePositionChanges, True)
-        self.setCursor(QtGui.QCursor(QtCore.Qt.SizeFDiagCursor))
+        self.setFlag(self.GraphicsItemFlag.ItemIsSelectable, True)
+        self.setFlag(self.GraphicsItemFlag.ItemIsMovable, True)
+        self.setFlag(self.GraphicsItemFlag.ItemSendsScenePositionChanges, True)
+        self.setCursor(QtGui.QCursor(QtCore.Qt.CursorShape.SizeFDiagCursor))
         self.setToolTip('double-click auto resize')
         self._size = size
 
@@ -38,7 +38,7 @@ class BackdropSizer(QtWidgets.QGraphicsItem):
         return QtCore.QRectF(0.5, 0.5, self._size, self._size)
 
     def itemChange(self, change, value):
-        if change == self.ItemPositionChange:
+        if change == self.GraphicsItemChange.ItemPositionChange:
             item = self.parentItem()
             mx, my = item.minimum_size
             x = mx if value.x() < mx else value.x()
@@ -95,7 +95,7 @@ class BackdropSizer(QtWidgets.QGraphicsItem):
         path.lineTo(rect.bottomRight())
         path.lineTo(rect.bottomLeft())
         painter.setBrush(color)
-        painter.setPen(QtCore.Qt.NoPen)
+        painter.setPen(QtCore.Qt.PenStyle.NoPen)
         painter.fillPath(path, painter.brush())
 
         painter.restore()
@@ -133,13 +133,13 @@ class BackdropNodeItem(AbstractNodeItem):
         super(BackdropNodeItem, self).mouseDoubleClickEvent(event)
 
     def mousePressEvent(self, event):
-        if event.button() == QtCore.Qt.LeftButton:
+        if event.button() == QtCore.Qt.MouseButton.LeftButton:
             pos = event.scenePos()
             rect = QtCore.QRectF(pos.x() - 5, pos.y() - 5, 10, 10)
             item = self.scene().items(rect)[0]
 
             if isinstance(item, (PortItem, PipeItem)):
-                self.setFlag(self.ItemIsMovable, False)
+                self.setFlag(self.GraphicsItemFlag.ItemIsMovable, False)
                 return
             if self.selected:
                 return
@@ -152,7 +152,7 @@ class BackdropNodeItem(AbstractNodeItem):
 
     def mouseReleaseEvent(self, event):
         super(BackdropNodeItem, self).mouseReleaseEvent(event)
-        self.setFlag(self.ItemIsMovable, True)
+        self.setFlag(self.GraphicsItemFlag.ItemIsMovable, True)
         [n.setSelected(True) for n in self._nodes]
         self._nodes = [self]
 
@@ -184,8 +184,8 @@ class BackdropNodeItem(AbstractNodeItem):
             widget (QtWidgets.QWidget): not used.
         """
         painter.save()
-        painter.setPen(QtCore.Qt.NoPen)
-        painter.setBrush(QtCore.Qt.NoBrush)
+        painter.setPen(QtCore.Qt.PenStyle.NoPen)
+        painter.setBrush(QtCore.Qt.BrushStyle.NoBrush)
 
         margin = 1.0
         rect = self.boundingRect()
@@ -197,12 +197,12 @@ class BackdropNodeItem(AbstractNodeItem):
         radius = 2.6
         color = (self.color[0], self.color[1], self.color[2], 50)
         painter.setBrush(QtGui.QColor(*color))
-        painter.setPen(QtCore.Qt.NoPen)
+        painter.setPen(QtCore.Qt.PenStyle.NoPen)
         painter.drawRoundedRect(rect, radius, radius)
 
         top_rect = QtCore.QRectF(rect.x(), rect.y(), rect.width(), 26.0)
         painter.setBrush(QtGui.QBrush(QtGui.QColor(*self.color)))
-        painter.setPen(QtCore.Qt.NoPen)
+        painter.setPen(QtCore.Qt.PenStyle.NoPen)
         painter.drawRoundedRect(top_rect, radius, radius)
         for pos in [top_rect.left(), top_rect.right() - 5.0]:
             painter.drawRect(
@@ -215,35 +215,35 @@ class BackdropNodeItem(AbstractNodeItem):
                 rect.width() - 5.0, rect.height())
             painter.setPen(QtGui.QColor(*self.text_color))
             painter.drawText(txt_rect,
-                             QtCore.Qt.AlignLeft | QtCore.Qt.TextWordWrap,
+                             QtCore.Qt.AlignmentFlag.AlignLeft | QtCore.Qt.TextFlag.TextWordWrap,
                              self.backdrop_text)
 
         if self.selected:
             sel_color = [x for x in NodeEnum.SELECTED_COLOR.value]
             sel_color[-1] = 15
             painter.setBrush(QtGui.QColor(*sel_color))
-            painter.setPen(QtCore.Qt.NoPen)
+            painter.setPen(QtCore.Qt.PenStyle.NoPen)
             painter.drawRoundedRect(rect, radius, radius)
 
         txt_rect = QtCore.QRectF(top_rect.x(), top_rect.y(),
                                  rect.width(), top_rect.height())
         painter.setPen(QtGui.QColor(*self.text_color))
-        painter.drawText(txt_rect, QtCore.Qt.AlignCenter, self.name)
+        painter.drawText(txt_rect, QtCore.Qt.AlignmentFlag.AlignCenter, self.name)
 
         border = 0.8
         border_color = self.color
         if self.selected and NodeEnum.SELECTED_BORDER_COLOR.value:
             border = 1.0
             border_color = NodeEnum.SELECTED_BORDER_COLOR.value
-        painter.setBrush(QtCore.Qt.NoBrush)
+        painter.setBrush(QtCore.Qt.BrushStyle.NoBrush)
         painter.setPen(QtGui.QPen(QtGui.QColor(*border_color), border))
         painter.drawRoundedRect(rect, radius, radius)
 
         painter.restore()
 
     def get_nodes(self, inc_intersects=False):
-        mode = {True: QtCore.Qt.IntersectsItemShape,
-                False: QtCore.Qt.ContainsItemShape}
+        mode = {True: QtCore.Qt.ItemSelectionMode.IntersectsItemShape,
+                False: QtCore.Qt.ItemSelectionMode.ContainsItemShape}
         nodes = []
         if self.scene():
             polygon = self.mapToScene(self.boundingRect())

--- a/NodeGraphQt/qgraphics/node_backdrop.py
+++ b/NodeGraphQt/qgraphics/node_backdrop.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-from Qt import QtGui, QtCore, QtWidgets
+from qtpy import QtGui, QtCore, QtWidgets
 
 from NodeGraphQt.constants import Z_VAL_BACKDROP, NodeEnum
 from NodeGraphQt.qgraphics.node_abstract import AbstractNodeItem

--- a/NodeGraphQt/qgraphics/node_base.py
+++ b/NodeGraphQt/qgraphics/node_base.py
@@ -34,11 +34,11 @@ class NodeItem(AbstractNodeItem):
         if pixmap.size().height() > NodeEnum.ICON_SIZE.value:
             pixmap = pixmap.scaledToHeight(
                 NodeEnum.ICON_SIZE.value,
-                QtCore.Qt.SmoothTransformation
+                QtCore.Qt.TransformationMode.SmoothTransformation
             )
         self._properties['icon'] = ICON_NODE_BASE
         self._icon_item = QtWidgets.QGraphicsPixmapItem(pixmap, self)
-        self._icon_item.setTransformationMode(QtCore.Qt.SmoothTransformation)
+        self._icon_item.setTransformationMode(QtCore.Qt.TransformationMode.SmoothTransformation)
         self._text_item = NodeTextItem(self.name, self)
         self._x_item = XDisabledItem(self, 'DISABLED')
         self._input_items = OrderedDict()
@@ -69,8 +69,8 @@ class NodeItem(AbstractNodeItem):
 
     def _paint_horizontal(self, painter, option, widget):
         painter.save()
-        painter.setPen(QtCore.Qt.NoPen)
-        painter.setBrush(QtCore.Qt.NoBrush)
+        painter.setPen(QtCore.Qt.PenStyle.NoPen)
+        painter.setBrush(QtCore.Qt.BrushStyle.NoBrush)
 
         # base background.
         margin = 1.0
@@ -119,7 +119,7 @@ class NodeItem(AbstractNodeItem):
         pen.setCosmetic(self.viewer().get_zoom() < 0.0)
         path = QtGui.QPainterPath()
         path.addRoundedRect(border_rect, radius, radius)
-        painter.setBrush(QtCore.Qt.NoBrush)
+        painter.setBrush(QtCore.Qt.BrushStyle.NoBrush)
         painter.setPen(pen)
         painter.drawPath(path)
 
@@ -127,8 +127,8 @@ class NodeItem(AbstractNodeItem):
 
     def _paint_vertical(self, painter, option, widget):
         painter.save()
-        painter.setPen(QtCore.Qt.NoPen)
-        painter.setBrush(QtCore.Qt.NoBrush)
+        painter.setPen(QtCore.Qt.PenStyle.NoPen)
+        painter.setBrush(QtCore.Qt.BrushStyle.NoBrush)
 
         # base background.
         margin = 1.0
@@ -174,7 +174,7 @@ class NodeItem(AbstractNodeItem):
 
         pen = QtGui.QPen(border_color, border_width)
         pen.setCosmetic(self.viewer().get_zoom() < 0.0)
-        painter.setBrush(QtCore.Qt.NoBrush)
+        painter.setBrush(QtCore.Qt.BrushStyle.NoBrush)
         painter.setPen(pen)
         painter.drawRoundedRect(border_rect, radius, radius)
 
@@ -205,7 +205,7 @@ class NodeItem(AbstractNodeItem):
         Args:
             event (QtWidgets.QGraphicsSceneMouseEvent): mouse event.
         """
-        if event.button() == QtCore.Qt.LeftButton:
+        if event.button() == QtCore.Qt.MouseButton.LeftButton:
             for p in self._input_items.keys():
                 if p.hovered:
                     event.ignore()
@@ -223,7 +223,7 @@ class NodeItem(AbstractNodeItem):
         Args:
             event (QtWidgets.QGraphicsSceneMouseEvent): mouse event.
         """
-        if event.modifiers() == QtCore.Qt.AltModifier:
+        if event.modifiers() == QtCore.Qt.KeyboardModifier.AltModifier:
             event.ignore()
             return
         super(NodeItem, self).mouseReleaseEvent(event)
@@ -235,7 +235,7 @@ class NodeItem(AbstractNodeItem):
         Args:
             event (QtWidgets.QGraphicsSceneMouseEvent): mouse event.
         """
-        if event.button() == QtCore.Qt.LeftButton:
+        if event.button() == QtCore.Qt.MouseButton.LeftButton:
             if not self.disabled:
                 # enable text item edit mode.
                 items = self.scene().items(event.scenePos())
@@ -258,7 +258,7 @@ class NodeItem(AbstractNodeItem):
             change:
             value:
         """
-        if change == self.ItemSelectedChange and self.scene():
+        if change == self.GraphicsItemChange.ItemSelectedChange and self.scene():
             self.reset_pipes()
             if value:
                 self.highlight_pipes()
@@ -802,7 +802,7 @@ class NodeItem(AbstractNodeItem):
         if pixmap.size().height() > NodeEnum.ICON_SIZE.value:
             pixmap = pixmap.scaledToHeight(
                 NodeEnum.ICON_SIZE.value,
-                QtCore.Qt.SmoothTransformation
+                QtCore.Qt.TransformationMode.SmoothTransformation
             )
         self._icon_item.setPixmap(pixmap)
         if self.scene():

--- a/NodeGraphQt/qgraphics/node_base.py
+++ b/NodeGraphQt/qgraphics/node_base.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 from collections import OrderedDict
 
-from Qt import QtGui, QtCore, QtWidgets
+from qtpy import QtGui, QtCore, QtWidgets
 
 from NodeGraphQt.constants import (
     ITEM_CACHE_MODE,

--- a/NodeGraphQt/qgraphics/node_circle.py
+++ b/NodeGraphQt/qgraphics/node_circle.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-from Qt import QtCore, QtGui, QtWidgets
+from qtpy import QtCore, QtGui, QtWidgets
 
 from NodeGraphQt.constants import NodeEnum, PortEnum
 from NodeGraphQt.qgraphics.node_base import NodeItem

--- a/NodeGraphQt/qgraphics/node_circle.py
+++ b/NodeGraphQt/qgraphics/node_circle.py
@@ -234,9 +234,9 @@ class CircleNodeItem(NodeItem):
         pen_color = QtGui.QColor(*self.border_color)
         pen_color.setAlpha(120)
         pen = QtGui.QPen(pen_color, 1.5)
-        pen.setCapStyle(QtCore.Qt.RoundCap)
+        pen.setCapStyle(QtCore.Qt.PenCapStyle.RoundCap)
         painter.setPen(pen)
-        painter.setBrush(QtCore.Qt.NoBrush)
+        painter.setBrush(QtCore.Qt.BrushStyle.NoBrush)
         for p in self.inputs:
             if p.isVisible():
                 p_text = self.get_input_text_item(p)
@@ -273,7 +273,7 @@ class CircleNodeItem(NodeItem):
 
         # draw the base color.
         painter.setBrush(QtGui.QColor(*self.color))
-        painter.setPen(QtCore.Qt.NoPen)
+        painter.setPen(QtCore.Qt.PenStyle.NoPen)
         painter.drawEllipse(rect)
 
         # draw outline.
@@ -291,7 +291,7 @@ class CircleNodeItem(NodeItem):
             border_color = QtGui.QColor(*self.border_color)
 
         # draw the outlines.
-        painter.setBrush(QtCore.Qt.NoBrush)
+        painter.setBrush(QtCore.Qt.BrushStyle.NoBrush)
         painter.setPen(QtGui.QPen(border_color, border_width))
         painter.drawEllipse(rect)
 
@@ -307,7 +307,7 @@ class CircleNodeItem(NodeItem):
             painter.setBrush(QtGui.QColor(*NodeEnum.SELECTED_COLOR.value))
         else:
             painter.setBrush(QtGui.QColor(0, 0, 0, 80))
-        painter.setPen(QtCore.Qt.NoPen)
+        painter.setPen(QtCore.Qt.PenStyle.NoPen)
         painter.drawRoundedRect(text_rect, 8.0, 8.0)
 
         painter.restore()
@@ -335,9 +335,9 @@ class CircleNodeItem(NodeItem):
         pen_color = QtGui.QColor(*self.border_color)
         pen_color.setAlpha(120)
         pen = QtGui.QPen(pen_color, 1.5)
-        pen.setCapStyle(QtCore.Qt.RoundCap)
+        pen.setCapStyle(QtCore.Qt.PenCapStyle.RoundCap)
         painter.setPen(pen)
-        painter.setBrush(QtCore.Qt.NoBrush)
+        painter.setBrush(QtCore.Qt.BrushStyle.NoBrush)
         for p in self.inputs:
             if p.isVisible():
                 pt1 = QtCore.QPointF(
@@ -364,7 +364,7 @@ class CircleNodeItem(NodeItem):
 
         # draw the base color.
         painter.setBrush(QtGui.QColor(*self.color))
-        painter.setPen(QtCore.Qt.NoPen)
+        painter.setPen(QtCore.Qt.PenStyle.NoPen)
         painter.drawEllipse(rect)
 
         # draw outline.
@@ -382,7 +382,7 @@ class CircleNodeItem(NodeItem):
             border_color = QtGui.QColor(*self.border_color)
 
         # draw the outlines.
-        painter.setBrush(QtCore.Qt.NoBrush)
+        painter.setBrush(QtCore.Qt.BrushStyle.NoBrush)
         painter.setPen(QtGui.QPen(border_color, border_width))
         painter.drawEllipse(rect)
 

--- a/NodeGraphQt/qgraphics/node_group.py
+++ b/NodeGraphQt/qgraphics/node_group.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-from Qt import QtCore, QtGui, QtWidgets
+from qtpy import QtCore, QtGui, QtWidgets
 
 from NodeGraphQt.constants import NodeEnum, PortEnum
 from NodeGraphQt.qgraphics.node_base import NodeItem

--- a/NodeGraphQt/qgraphics/node_group.py
+++ b/NodeGraphQt/qgraphics/node_group.py
@@ -19,8 +19,8 @@ class GroupNodeItem(NodeItem):
 
     def _paint_horizontal(self, painter, option, widget):
         painter.save()
-        painter.setBrush(QtCore.Qt.NoBrush)
-        painter.setPen(QtCore.Qt.NoPen)
+        painter.setBrush(QtCore.Qt.BrushStyle.NoBrush)
+        painter.setPen(QtCore.Qt.PenStyle.NoPen)
 
         # base background.
         margin = 6.0
@@ -72,14 +72,14 @@ class GroupNodeItem(NodeItem):
             painter.setBrush(QtGui.QColor(*NodeEnum.SELECTED_COLOR.value))
         else:
             painter.setBrush(QtGui.QColor(0, 0, 0, 80))
-        painter.setPen(QtCore.Qt.NoPen)
+        painter.setPen(QtCore.Qt.PenStyle.NoPen)
         painter.drawRect(text_rect)
 
         # draw the outlines.
         pen = QtGui.QPen(border_color.darker(120), 0.8)
-        pen.setJoinStyle(QtCore.Qt.RoundJoin)
-        pen.setCapStyle(QtCore.Qt.RoundCap)
-        painter.setBrush(QtCore.Qt.NoBrush)
+        pen.setJoinStyle(QtCore.Qt.PenJoinStyle.RoundJoin)
+        pen.setCapStyle(QtCore.Qt.PenCapStyle.RoundCap)
+        painter.setBrush(QtCore.Qt.BrushStyle.NoBrush)
         painter.setPen(pen)
         painter.drawLines([rect_1.topRight(), rect_2.topRight(),
                            rect_1.topRight(), rect_1.bottomRight(),
@@ -88,8 +88,8 @@ class GroupNodeItem(NodeItem):
         painter.drawLine(rect_1.bottomRight(), rect_2.bottomRight())
 
         pen = QtGui.QPen(border_color, 0.8)
-        pen.setJoinStyle(QtCore.Qt.MiterJoin)
-        pen.setCapStyle(QtCore.Qt.RoundCap)
+        pen.setJoinStyle(QtCore.Qt.PenJoinStyle.MiterJoin)
+        pen.setCapStyle(QtCore.Qt.PenCapStyle.RoundCap)
         painter.setPen(pen)
         painter.drawRect(rect_2)
 
@@ -97,8 +97,8 @@ class GroupNodeItem(NodeItem):
 
     def _paint_vertical(self, painter, option, widget):
         painter.save()
-        painter.setBrush(QtCore.Qt.NoBrush)
-        painter.setPen(QtCore.Qt.NoPen)
+        painter.setBrush(QtCore.Qt.BrushStyle.NoBrush)
+        painter.setPen(QtCore.Qt.PenStyle.NoPen)
 
         # base background.
         margin = 6.0
@@ -146,7 +146,7 @@ class GroupNodeItem(NodeItem):
         else:
             painter.setBrush(QtGui.QColor(0, 0, 0, 80))
 
-        painter.setPen(QtCore.Qt.NoPen)
+        painter.setPen(QtCore.Qt.PenStyle.NoPen)
         for y in [rect_2.top() + padding, rect_2.bottom() - height - padding]:
             top_rect = QtCore.QRectF(rect.x() + padding - offset, y,
                                      rect.width() - (padding * 2), height)
@@ -154,9 +154,9 @@ class GroupNodeItem(NodeItem):
 
         # draw the outlines.
         pen = QtGui.QPen(border_color.darker(120), 0.8)
-        pen.setJoinStyle(QtCore.Qt.MiterJoin)
-        pen.setCapStyle(QtCore.Qt.RoundCap)
-        painter.setBrush(QtCore.Qt.NoBrush)
+        pen.setJoinStyle(QtCore.Qt.PenJoinStyle.MiterJoin)
+        pen.setCapStyle(QtCore.Qt.PenCapStyle.RoundCap)
+        painter.setBrush(QtCore.Qt.BrushStyle.NoBrush)
         painter.setPen(pen)
         painter.drawLines([rect_1.topRight(), rect_2.topRight(),
                            rect_1.topRight(), rect_1.bottomRight(),
@@ -165,8 +165,8 @@ class GroupNodeItem(NodeItem):
         painter.drawLine(rect_1.bottomRight(), rect_2.bottomRight())
 
         pen = QtGui.QPen(border_color, 0.8)
-        pen.setJoinStyle(QtCore.Qt.MiterJoin)
-        pen.setCapStyle(QtCore.Qt.RoundCap)
+        pen.setJoinStyle(QtCore.Qt.PenJoinStyle.MiterJoin)
+        pen.setCapStyle(QtCore.Qt.PenCapStyle.RoundCap)
         painter.setPen(pen)
         painter.drawRect(rect_2)
 

--- a/NodeGraphQt/qgraphics/node_overlay_disabled.py
+++ b/NodeGraphQt/qgraphics/node_overlay_disabled.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-from Qt import QtGui, QtCore, QtWidgets
+from qtpy import QtGui, QtCore, QtWidgets
 
 from NodeGraphQt.constants import Z_VAL_NODE_WIDGET
 

--- a/NodeGraphQt/qgraphics/node_overlay_disabled.py
+++ b/NodeGraphQt/qgraphics/node_overlay_disabled.py
@@ -44,7 +44,7 @@ class XDisabledItem(QtWidgets.QGraphicsItem):
                                  rect.height() + margin)
         if not self.proxy_mode:
             pen = QtGui.QPen(QtGui.QColor(*self.color), 8)
-            pen.setCapStyle(QtCore.Qt.RoundCap)
+            pen.setCapStyle(QtCore.Qt.PenCapStyle.RoundCap)
             painter.setPen(pen)
             painter.drawLine(dis_rect.topLeft(), dis_rect.bottomRight())
             painter.drawLine(dis_rect.topRight(), dis_rect.bottomLeft())

--- a/NodeGraphQt/qgraphics/node_port_in.py
+++ b/NodeGraphQt/qgraphics/node_port_in.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-from Qt import QtCore, QtGui, QtWidgets
+from qtpy import QtCore, QtGui, QtWidgets
 
 from NodeGraphQt.constants import NodeEnum
 from NodeGraphQt.qgraphics.node_base import NodeItem

--- a/NodeGraphQt/qgraphics/node_port_in.py
+++ b/NodeGraphQt/qgraphics/node_port_in.py
@@ -29,8 +29,8 @@ class PortInputNodeItem(NodeItem):
         self.auto_switch_mode()
 
         painter.save()
-        painter.setBrush(QtCore.Qt.NoBrush)
-        painter.setPen(QtCore.Qt.NoPen)
+        painter.setBrush(QtCore.Qt.BrushStyle.NoBrush)
+        painter.setPen(QtCore.Qt.PenStyle.NoPen)
 
         margin = 2.0
         rect = self.boundingRect()
@@ -73,7 +73,7 @@ class PortInputNodeItem(NodeItem):
             pen = QtGui.QPen(QtGui.QColor(*self.border_color), 1.2)
             painter.setBrush(QtGui.QColor(0, 0, 0, 50))
 
-        pen.setJoinStyle(QtCore.Qt.MiterJoin)
+        pen.setJoinStyle(QtCore.Qt.PenJoinStyle.MiterJoin)
         painter.setPen(pen)
         painter.drawPolygon(poly)
 
@@ -89,8 +89,8 @@ class PortInputNodeItem(NodeItem):
         self.auto_switch_mode()
 
         painter.save()
-        painter.setBrush(QtCore.Qt.NoBrush)
-        painter.setPen(QtCore.Qt.NoPen)
+        painter.setBrush(QtCore.Qt.BrushStyle.NoBrush)
+        painter.setPen(QtCore.Qt.PenStyle.NoPen)
 
         margin = 2.0
         rect = self.boundingRect()
@@ -133,7 +133,7 @@ class PortInputNodeItem(NodeItem):
             pen = QtGui.QPen(QtGui.QColor(*self.border_color), 1.2)
             painter.setBrush(QtGui.QColor(0, 0, 0, 50))
 
-        pen.setJoinStyle(QtCore.Qt.MiterJoin)
+        pen.setJoinStyle(QtCore.Qt.PenJoinStyle.MiterJoin)
         painter.setPen(pen)
         painter.drawPolygon(poly)
 

--- a/NodeGraphQt/qgraphics/node_port_out.py
+++ b/NodeGraphQt/qgraphics/node_port_out.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-from Qt import QtCore, QtGui, QtWidgets
+from qtpy import QtCore, QtGui, QtWidgets
 
 from NodeGraphQt.constants import NodeEnum
 from NodeGraphQt.qgraphics.node_base import NodeItem

--- a/NodeGraphQt/qgraphics/node_port_out.py
+++ b/NodeGraphQt/qgraphics/node_port_out.py
@@ -29,8 +29,8 @@ class PortOutputNodeItem(NodeItem):
         self.auto_switch_mode()
 
         painter.save()
-        painter.setBrush(QtCore.Qt.NoBrush)
-        painter.setPen(QtCore.Qt.NoPen)
+        painter.setBrush(QtCore.Qt.BrushStyle.NoBrush)
+        painter.setPen(QtCore.Qt.PenStyle.NoPen)
 
         margin = 2.0
         rect = self.boundingRect()
@@ -73,7 +73,7 @@ class PortOutputNodeItem(NodeItem):
             pen = QtGui.QPen(QtGui.QColor(*self.border_color), 1.2)
             painter.setBrush(QtGui.QColor(0, 0, 0, 50))
 
-        pen.setJoinStyle(QtCore.Qt.MiterJoin)
+        pen.setJoinStyle(QtCore.Qt.PenJoinStyle.MiterJoin)
         painter.setPen(pen)
         painter.drawPolygon(poly)
 
@@ -89,8 +89,8 @@ class PortOutputNodeItem(NodeItem):
         self.auto_switch_mode()
 
         painter.save()
-        painter.setBrush(QtCore.Qt.NoBrush)
-        painter.setPen(QtCore.Qt.NoPen)
+        painter.setBrush(QtCore.Qt.BrushStyle.NoBrush)
+        painter.setPen(QtCore.Qt.PenStyle.NoPen)
 
         margin = 2.0
         rect = self.boundingRect()
@@ -133,7 +133,7 @@ class PortOutputNodeItem(NodeItem):
             pen = QtGui.QPen(QtGui.QColor(*self.border_color), 1.2)
             painter.setBrush(QtGui.QColor(0, 0, 0, 50))
 
-        pen.setJoinStyle(QtCore.Qt.MiterJoin)
+        pen.setJoinStyle(QtCore.Qt.PenJoinStyle.MiterJoin)
         painter.setPen(pen)
         painter.drawPolygon(poly)
 

--- a/NodeGraphQt/qgraphics/node_text_item.py
+++ b/NodeGraphQt/qgraphics/node_text_item.py
@@ -1,4 +1,4 @@
-from Qt import QtWidgets, QtCore, QtGui
+from qtpy import QtWidgets, QtCore, QtGui
 
 
 class NodeTextItem(QtWidgets.QGraphicsTextItem):

--- a/NodeGraphQt/qgraphics/node_text_item.py
+++ b/NodeGraphQt/qgraphics/node_text_item.py
@@ -20,7 +20,7 @@ class NodeTextItem(QtWidgets.QGraphicsTextItem):
             event (QtWidgets.QGraphicsSceneMouseEvent): mouse event.
         """
         if not self._locked:
-            if event.button() == QtCore.Qt.LeftButton:
+            if event.button() == QtCore.Qt.MouseButton.LeftButton:
                 self.set_editable(True)
                 event.ignore()
                 return
@@ -33,11 +33,11 @@ class NodeTextItem(QtWidgets.QGraphicsTextItem):
         Args:
             event (QtGui.QKeyEvent): key event.
         """
-        if event.key() == QtCore.Qt.Key_Return:
+        if event.key() == QtCore.Qt.Key.Key_Return:
             current_text = self.toPlainText()
             self.set_node_name(current_text)
             self.set_editable(False)
-        elif event.key() == QtCore.Qt.Key_Escape:
+        elif event.key() == QtCore.Qt.Key.Key_Escape:
             self.setPlainText(self.node.name)
             self.set_editable(False)
         super(NodeTextItem, self).keyPressEvent(event)
@@ -65,12 +65,12 @@ class NodeTextItem(QtWidgets.QGraphicsTextItem):
             return
         if value:
             self.setTextInteractionFlags(
-                QtCore.Qt.TextEditable |
-                QtCore.Qt.TextSelectableByMouse |
-                QtCore.Qt.TextSelectableByKeyboard
+                QtCore.Qt.TextInteractionFlag.TextEditable |
+                QtCore.Qt.TextInteractionFlag.TextSelectableByMouse |
+                QtCore.Qt.TextInteractionFlag.TextSelectableByKeyboard
             )
         else:
-            self.setTextInteractionFlags(QtCore.Qt.NoTextInteraction)
+            self.setTextInteractionFlags(QtCore.Qt.TextInteractionFlag.NoTextInteraction)
             cursor = self.textCursor()
             cursor.clearSelection()
             self.setTextCursor(cursor)
@@ -99,12 +99,12 @@ class NodeTextItem(QtWidgets.QGraphicsTextItem):
         self._locked = state
         if self._locked:
             self.setFlag(QtWidgets.QGraphicsItem.ItemIsFocusable, False)
-            self.setCursor(QtCore.Qt.ArrowCursor)
+            self.setCursor(QtCore.Qt.CursorShape.ArrowCursor)
             self.setToolTip('')
         else:
             self.setFlag(QtWidgets.QGraphicsItem.ItemIsFocusable, True)
             self.setToolTip('double-click to edit node name.')
-            self.setCursor(QtCore.Qt.IBeamCursor)
+            self.setCursor(QtCore.Qt.CursorShape.IBeamCursor)
 
     @property
     def node(self):

--- a/NodeGraphQt/qgraphics/pipe.py
+++ b/NodeGraphQt/qgraphics/pipe.py
@@ -15,9 +15,9 @@ from NodeGraphQt.constants import (
 from NodeGraphQt.qgraphics.port import PortItem
 
 PIPE_STYLES = {
-    PipeEnum.DRAW_TYPE_DEFAULT.value: QtCore.Qt.SolidLine,
-    PipeEnum.DRAW_TYPE_DASHED.value: QtCore.Qt.DashLine,
-    PipeEnum.DRAW_TYPE_DOTTED.value: QtCore.Qt.DotLine
+    PipeEnum.DRAW_TYPE_DEFAULT.value: QtCore.Qt.PenStyle.SolidLine,
+    PipeEnum.DRAW_TYPE_DASHED.value: QtCore.Qt.PenStyle.DashLine,
+    PipeEnum.DRAW_TYPE_DOTTED.value: QtCore.Qt.PenStyle.DotLine
 }
 
 
@@ -72,7 +72,7 @@ class PipeItem(QtWidgets.QGraphicsPathItem):
             self.highlight()
 
     def itemChange(self, change, value):
-        if change == self.ItemSelectedChange and self.scene():
+        if change == self.GraphicsItemChange.ItemSelectedChange and self.scene():
             if value:
                 self.highlight()
             else:
@@ -100,7 +100,7 @@ class PipeItem(QtWidgets.QGraphicsPathItem):
 
         painter.setPen(pen)
         painter.setBrush(self.brush())
-        painter.setRenderHint(painter.Antialiasing, True)
+        painter.setRenderHint(painter.RenderHint.Antialiasing, True)
         painter.drawPath(self.path())
 
         # QPaintDevice: Cannot destroy paint device that is being painted.
@@ -427,14 +427,14 @@ class PipeItem(QtWidgets.QGraphicsPathItem):
         pen.setWidth(width)
         pen.setColor(QtGui.QColor(*color))
         pen.setStyle(PIPE_STYLES.get(style))
-        pen.setJoinStyle(QtCore.Qt.MiterJoin)
-        pen.setCapStyle(QtCore.Qt.RoundCap)
+        pen.setJoinStyle(QtCore.Qt.PenJoinStyle.MiterJoin)
+        pen.setCapStyle(QtCore.Qt.PenCapStyle.RoundCap)
         self.setPen(pen)
         self.setBrush(QtGui.QBrush(QtCore.Qt.NoBrush))
 
         pen = self._dir_pointer.pen()
-        pen.setJoinStyle(QtCore.Qt.MiterJoin)
-        pen.setCapStyle(QtCore.Qt.RoundCap)
+        pen.setJoinStyle(QtCore.Qt.PenJoinStyle.MiterJoin)
+        pen.setCapStyle(QtCore.Qt.PenCapStyle.RoundCap)
         pen.setWidth(width)
         pen.setColor(QtGui.QColor(*color))
         self._dir_pointer.setPen(pen)

--- a/NodeGraphQt/qgraphics/pipe.py
+++ b/NodeGraphQt/qgraphics/pipe.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 import math
 
-from Qt import QtCore, QtGui, QtWidgets
+from qtpy import QtCore, QtGui, QtWidgets
 
 from NodeGraphQt.constants import (
     LayoutDirectionEnum,

--- a/NodeGraphQt/qgraphics/pipe.py
+++ b/NodeGraphQt/qgraphics/pipe.py
@@ -48,7 +48,7 @@ class PipeItem(QtWidgets.QGraphicsPathItem):
 
         self._dir_pointer = QtWidgets.QGraphicsPolygonItem(self)
         self._dir_pointer.setPolygon(self._poly)
-        self._dir_pointer.setFlag(self.ItemIsSelectable, False)
+        self._dir_pointer.setFlag(self.GraphicsItemFlag.ItemIsSelectable, False)
 
         self.reset()
 

--- a/NodeGraphQt/qgraphics/port.py
+++ b/NodeGraphQt/qgraphics/port.py
@@ -16,8 +16,8 @@ class PortItem(QtWidgets.QGraphicsItem):
         super(PortItem, self).__init__(parent)
         self.setAcceptHoverEvents(True)
         self.setCacheMode(ITEM_CACHE_MODE)
-        self.setFlag(self.ItemIsSelectable, False)
-        self.setFlag(self.ItemSendsScenePositionChanges, True)
+        self.setFlag(self.GraphicsItemFlag.ItemIsSelectable, False)
+        self.setFlag(self.GraphicsItemFlag.ItemSendsScenePositionChanges, True)
         self.setZValue(Z_VAL_PORT)
         self._pipes = []
         self._width = PortEnum.SIZE.value
@@ -114,7 +114,7 @@ class PortItem(QtWidgets.QGraphicsItem):
         painter.restore()
 
     def itemChange(self, change, value):
-        if change == self.ItemScenePositionHasChanged:
+        if change == self.GraphicsItemChange.ItemScenePositionHasChanged:
             self.redraw_connected_pipes()
         return super(PortItem, self).itemChange(change, value)
 

--- a/NodeGraphQt/qgraphics/port.py
+++ b/NodeGraphQt/qgraphics/port.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-from Qt import QtGui, QtCore, QtWidgets
+from qtpy import QtGui, QtCore, QtWidgets
 
 from NodeGraphQt.constants import (
     PortTypeEnum, PortEnum,

--- a/NodeGraphQt/qgraphics/slicer.py
+++ b/NodeGraphQt/qgraphics/slicer.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 import math
 
-from Qt import QtCore, QtGui, QtWidgets
+from qtpy import QtCore, QtGui, QtWidgets
 
 from NodeGraphQt.constants import Z_VAL_NODE_WIDGET, PipeSlicerEnum
 

--- a/NodeGraphQt/qgraphics/slicer.py
+++ b/NodeGraphQt/qgraphics/slicer.py
@@ -33,7 +33,7 @@ class SlicerPipeItem(QtWidgets.QGraphicsPathItem):
         arrow_size = 4.0
 
         painter.save()
-        painter.setRenderHint(painter.Antialiasing, True)
+        painter.setRenderHint(painter.RenderHint.Antialiasing, True)
 
         font = painter.font()
         font.setPointSize(12)

--- a/NodeGraphQt/qgraphics/slicer.py
+++ b/NodeGraphQt/qgraphics/slicer.py
@@ -45,20 +45,20 @@ class SlicerPipeItem(QtWidgets.QGraphicsPathItem):
         text_color = QtGui.QColor(*PipeSlicerEnum.COLOR.value)
         text_color.setAlpha(80)
         painter.setPen(QtGui.QPen(
-            text_color, PipeSlicerEnum.WIDTH.value, QtCore.Qt.SolidLine
+            text_color, PipeSlicerEnum.WIDTH.value, QtCore.Qt.PenStyle.SolidLine
         ))
         painter.drawText(text_pos, text)
 
         painter.setPen(QtGui.QPen(
-            color, PipeSlicerEnum.WIDTH.value, QtCore.Qt.DashDotLine
+            color, PipeSlicerEnum.WIDTH.value, QtCore.Qt.PenStyle.DashDotLine
         ))
         painter.drawPath(self.path())
 
         pen = QtGui.QPen(
-            color, PipeSlicerEnum.WIDTH.value, QtCore.Qt.SolidLine
+            color, PipeSlicerEnum.WIDTH.value, QtCore.Qt.PenStyle.SolidLine
         )
-        pen.setCapStyle(QtCore.Qt.RoundCap)
-        pen.setJoinStyle(QtCore.Qt.MiterJoin)
+        pen.setCapStyle(QtCore.Qt.PenCapStyle.RoundCap)
+        pen.setJoinStyle(QtCore.Qt.PenJoinStyle.MiterJoin)
         painter.setPen(pen)
         painter.setBrush(color)
 

--- a/NodeGraphQt/widgets/actions.py
+++ b/NodeGraphQt/widgets/actions.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-from Qt import QtCore, QtWidgets
+from qtpy import QtCore, QtWidgets
 
 from NodeGraphQt.constants import ViewerEnum
 

--- a/NodeGraphQt/widgets/dialogs.py
+++ b/NodeGraphQt/widgets/dialogs.py
@@ -1,6 +1,6 @@
 import os
 
-from Qt import QtWidgets, QtGui, QtCore
+from qtpy import QtWidgets, QtGui, QtCore
 
 _current_user_directory = os.path.expanduser('~')
 

--- a/NodeGraphQt/widgets/node_graph.py
+++ b/NodeGraphQt/widgets/node_graph.py
@@ -1,4 +1,4 @@
-from Qt import QtWidgets, QtGui
+from qtpy import QtWidgets, QtGui
 
 from NodeGraphQt.constants import (
     NodeEnum, ViewerEnum, ViewerNavEnum

--- a/NodeGraphQt/widgets/node_widgets.py
+++ b/NodeGraphQt/widgets/node_widgets.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-from Qt import QtCore, QtWidgets
+from qtpy import QtCore, QtWidgets
 
 from NodeGraphQt.constants import ViewerEnum, Z_VAL_NODE_WIDGET
 from NodeGraphQt.errors import NodeWidgetError

--- a/NodeGraphQt/widgets/node_widgets.py
+++ b/NodeGraphQt/widgets/node_widgets.py
@@ -287,7 +287,7 @@ class NodeComboBox(NodeBaseWidget):
             combo_widget.addItems(text)
             return
         if text != self.get_value():
-            index = combo_widget.findText(text, QtCore.Qt.MatchExactly)
+            index = combo_widget.findText(text, QtCore.Qt.MatchFlag.MatchExactly)
             combo_widget.setCurrentIndex(index)
 
     def add_item(self, item):
@@ -354,7 +354,7 @@ class NodeLineEdit(NodeBaseWidget):
         ledit.setText(text)
         ledit.setPlaceholderText(placeholder_text)
         ledit.setStyleSheet(stylesheet)
-        ledit.setAlignment(QtCore.Qt.AlignCenter)
+        ledit.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
         ledit.editingFinished.connect(self.on_value_changed)
         ledit.clearFocus()
         self.set_custom_widget(ledit)

--- a/NodeGraphQt/widgets/scene.py
+++ b/NodeGraphQt/widgets/scene.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-from Qt import QtGui, QtCore, QtWidgets
+from qtpy import QtGui, QtCore, QtWidgets
 
 from NodeGraphQt.constants import ViewerEnum
 

--- a/NodeGraphQt/widgets/scene.py
+++ b/NodeGraphQt/widgets/scene.py
@@ -91,7 +91,7 @@ class NodeScene(QtWidgets.QGraphicsScene):
         super(NodeScene, self).drawBackground(painter, rect)
 
         painter.save()
-        painter.setRenderHint(QtGui.QPainter.Antialiasing, False)
+        painter.setRenderHint(QtGui.QPainter.RenderHint.Antialiasing, False)
         painter.setBrush(self.backgroundBrush())
 
         if self._grid_mode is ViewerEnum.GRID_DISPLAY_DOTS.value:

--- a/NodeGraphQt/widgets/scene.py
+++ b/NodeGraphQt/widgets/scene.py
@@ -122,9 +122,9 @@ class NodeScene(QtWidgets.QGraphicsScene):
             self.viewer().sceneMousePressEvent(event)
         super(NodeScene, self).mousePressEvent(event)
         keep_selection = any([
-            event.button() == QtCore.Qt.MiddleButton,
-            event.button() == QtCore.Qt.RightButton,
-            event.modifiers() == QtCore.Qt.AltModifier
+            event.button() == QtCore.Qt.MouseButton.MiddleButton,
+            event.button() == QtCore.Qt.MouseButton.RightButton,
+            event.modifiers() == QtCore.Qt.KeyboardModifier.AltModifier
         ])
         if keep_selection:
             for node in selected_nodes:

--- a/NodeGraphQt/widgets/tab_search.py
+++ b/NodeGraphQt/widgets/tab_search.py
@@ -2,7 +2,7 @@
 import re
 from collections import OrderedDict
 
-from Qt import QtCore, QtWidgets, QtGui
+from qtpy import QtCore, QtWidgets, QtGui
 
 from NodeGraphQt.constants import ViewerEnum, ViewerNavEnum
 

--- a/NodeGraphQt/widgets/tab_search.py
+++ b/NodeGraphQt/widgets/tab_search.py
@@ -15,8 +15,8 @@ class TabSearchCompleter(QtWidgets.QCompleter):
 
     def __init__(self, nodes=None, parent=None):
         super(TabSearchCompleter, self).__init__(nodes, parent)
-        self.setCompletionMode(self.PopupCompletion)
-        self.setCaseSensitivity(QtCore.Qt.CaseInsensitive)
+        self.setCompletionMode(self.CompletionMode.PopupCompletion)
+        self.setCaseSensitivity(QtCore.Qt.CaseSensitivity.CaseInsensitive)
         self._local_completion_prefix = ''
         self._using_orig_model = False
         self._source_model = None
@@ -35,11 +35,14 @@ class TabSearchCompleter(QtWidgets.QCompleter):
     def updateModel(self):
         if not self._using_orig_model:
             self._filter_model.setSourceModel(self._source_model)
-
-        pattern = QtCore.QRegExp(self._local_completion_prefix,
-                                 QtCore.Qt.CaseInsensitive,
-                                 QtCore.QRegExp.FixedString)
-        self._filter_model.setFilterRegExp(pattern)
+        # # https://doc.qt.io/qtforpython-6/overviews/qtcore-changes-qt6.html#the-qregularexpression-class
+        # pattern = QtCore.QRegExp(self._local_completion_prefix,
+        #                          QtCore.Qt.CaseSensitivity.CaseInsensitive,
+        #                          QtCore.QRegExp.FixedString)
+        # self._filter_model.setFilterRegExp(pattern)
+        # TODO: review these changes
+        self._filter_model.setFilterCaseSensitivity(QtCore.Qt.CaseSensitivity.CaseInsensitive)
+        self._filter_model.setFilterFixedString(self._local_completion_prefix)
 
     def setModel(self, model):
         self._source_model = model
@@ -55,7 +58,7 @@ class TabSearchLineEditWidget(QtWidgets.QLineEdit):
 
     def __init__(self, parent=None):
         super(TabSearchLineEditWidget, self).__init__(parent)
-        self.setAttribute(QtCore.Qt.WA_MacShowFocusRect, 0)
+        self.setAttribute(QtCore.Qt.WidgetAttribute.WA_MacShowFocusRect, 0)
         self.setMinimumSize(200, 22)
         # text_color = self.palette().text().color().getRgb()
         text_color = tuple(map(lambda i, j: i - j, (255, 255, 255),
@@ -88,7 +91,7 @@ class TabSearchLineEditWidget(QtWidgets.QLineEdit):
 
     def keyPressEvent(self, event):
         super(TabSearchLineEditWidget, self).keyPressEvent(event)
-        if event.key() == QtCore.Qt.Key_Tab:
+        if event.key() == QtCore.Qt.Key.Key_Tab:
             self.tab_pressed.emit()
 
 

--- a/NodeGraphQt/widgets/viewer.py
+++ b/NodeGraphQt/widgets/viewer.py
@@ -3,7 +3,7 @@
 import math
 from distutils.version import LooseVersion
 
-from Qt import QtGui, QtCore, QtWidgets
+from qtpy import QtGui, QtCore, QtWidgets
 
 from NodeGraphQt.base.menu import BaseMenu
 from NodeGraphQt.constants import (
@@ -1638,7 +1638,7 @@ class NodeViewer(QtWidgets.QGraphicsView):
         """
         # use QOpenGLWidget instead of the deprecated QGLWidget to avoid
         # problems with Wayland.
-        import Qt
+        import qtpy
         if Qt.IsPySide2:
             from PySide2.QtWidgets import QOpenGLWidget
         elif Qt.IsPyQt5:

--- a/NodeGraphQt/widgets/viewer.py
+++ b/NodeGraphQt/widgets/viewer.py
@@ -102,7 +102,7 @@ class NodeViewer(QtWidgets.QGraphicsView):
         )))
         text_color.setAlpha(50)
         self._cursor_text = QtWidgets.QGraphicsTextItem()
-        self._cursor_text.setFlag(self._cursor_text.ItemIsSelectable, False)
+        self._cursor_text.setFlag(self._cursor_text.GraphicsItemFlag.ItemIsSelectable, False)
         self._cursor_text.setDefaultTextColor(text_color)
         self._cursor_text.setZValue(Z_VAL_PIPE - 1)
         font = self._cursor_text.font()
@@ -616,7 +616,7 @@ class NodeViewer(QtWidgets.QGraphicsView):
                 path.addRect(map_rect)
                 self._rubber_band.setGeometry(rect)
                 self.scene().setSelectionArea(
-                    path, QtCore.Qt.ItemSelectionMode.IntersectsItemShape
+                    path, mode=QtCore.Qt.ItemSelectionMode.IntersectsItemShape
                 )
                 self.scene().update(map_rect)
 

--- a/NodeGraphQt/widgets/viewer.py
+++ b/NodeGraphQt/widgets/viewer.py
@@ -673,7 +673,7 @@ class NodeViewer(QtWidgets.QGraphicsView):
         pos = self.mapToScene(event.pos())
         event.setDropAction(QtCore.Qt.DropAction.CopyAction)
         self.data_dropped.emit(
-            event.mimeData(), QtCore.QPoint(pos.x(), pos.y())
+            event.mimeData(), QtCore.QPointF(pos.x(), pos.y())
         )
 
     def dragEnterEvent(self, event):

--- a/NodeGraphQt/widgets/viewer.py
+++ b/NodeGraphQt/widgets/viewer.py
@@ -57,19 +57,19 @@ class NodeViewer(QtWidgets.QGraphicsView):
         """
         Args:
             parent:
-            undo_stack (QtWidgets.QUndoStack): undo stack from the parent
+            undo_stack (QtGui.QUndoStack): undo stack from the parent
                                                graph controller.
         """
         super(NodeViewer, self).__init__(parent)
 
         self.setScene(NodeScene(self))
-        self.setRenderHint(QtGui.QPainter.Antialiasing, True)
-        self.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
-        self.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
-        self.setViewportUpdateMode(QtWidgets.QGraphicsView.FullViewportUpdate)
-        self.setCacheMode(QtWidgets.QGraphicsView.CacheBackground)
+        self.setRenderHint(QtGui.QPainter.RenderHint.Antialiasing, True)
+        self.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        self.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        self.setViewportUpdateMode(QtWidgets.QGraphicsView.ViewportUpdateMode.FullViewportUpdate)
+        self.setCacheMode(QtWidgets.QGraphicsView.CacheModeFlag.CacheBackground)
         self.setOptimizationFlag(
-            QtWidgets.QGraphicsView.DontAdjustForAntialiasing)
+            QtWidgets.QGraphicsView.OptimizationFlag.DontAdjustForAntialiasing)
 
         self.setAcceptDrops(True)
         self.resize(850, 800)
@@ -92,7 +92,7 @@ class NodeViewer(QtWidgets.QGraphicsView):
         self._node_positions = {}
 
         self._rubber_band = QtWidgets.QRubberBand(
-            QtWidgets.QRubberBand.Rectangle, self
+            QtWidgets.QRubberBand.Shape.Rectangle, self
         )
         self._rubber_band.isActive = False
 
@@ -199,8 +199,8 @@ class NodeViewer(QtWidgets.QGraphicsView):
 
         # setup the undo and redo actions.
         if self._undo_action and self._redo_action:
-            self._undo_action.setShortcuts(QtGui.QKeySequence.Undo)
-            self._redo_action.setShortcuts(QtGui.QKeySequence.Redo)
+            self._undo_action.setShortcuts(QtGui.QKeySequence.StandardKey.Undo)
+            self._redo_action.setShortcuts(QtGui.QKeySequence.StandardKey.Redo)
             if LooseVersion(QtCore.qVersion()) >= LooseVersion('5.10'):
                 self._undo_action.setShortcutVisibleInContextMenu(True)
                 self._redo_action.setShortcutVisibleInContextMenu(True)
@@ -267,7 +267,7 @@ class NodeViewer(QtWidgets.QGraphicsView):
         Redraw the scene.
         """
         self.setSceneRect(self._scene_range)
-        self.fitInView(self._scene_range, QtCore.Qt.KeepAspectRatio)
+        self.fitInView(self._scene_range, QtCore.Qt.AspectRatioMode.KeepAspectRatio)
 
     def _combined_rect(self, nodes):
         """
@@ -386,11 +386,11 @@ class NodeViewer(QtWidgets.QGraphicsView):
         return super(NodeViewer, self).contextMenuEvent(event)
 
     def mousePressEvent(self, event):
-        if event.button() == QtCore.Qt.LeftButton:
+        if event.button() == QtCore.Qt.MouseButton.LeftButton:
             self.LMB_state = True
-        elif event.button() == QtCore.Qt.RightButton:
+        elif event.button() == QtCore.Qt.MouseButton.RightButton:
             self.RMB_state = True
-        elif event.button() == QtCore.Qt.MiddleButton:
+        elif event.button() == QtCore.Qt.MouseButton.MiddleButton:
             self.MMB_state = True
 
         self._origin_pos = event.pos()
@@ -510,11 +510,11 @@ class NodeViewer(QtWidgets.QGraphicsView):
             super(NodeViewer, self).mousePressEvent(event)
 
     def mouseReleaseEvent(self, event):
-        if event.button() == QtCore.Qt.LeftButton:
+        if event.button() == QtCore.Qt.MouseButton.LeftButton:
             self.LMB_state = False
-        elif event.button() == QtCore.Qt.RightButton:
+        elif event.button() == QtCore.Qt.MouseButton.RightButton:
             self.RMB_state = False
-        elif event.button() == QtCore.Qt.MiddleButton:
+        elif event.button() == QtCore.Qt.MouseButton.MiddleButton:
             self.MMB_state = False
 
         # hide pipe slicer.
@@ -616,7 +616,7 @@ class NodeViewer(QtWidgets.QGraphicsView):
                 path.addRect(map_rect)
                 self._rubber_band.setGeometry(rect)
                 self.scene().setSelectionArea(
-                    path, QtCore.Qt.IntersectsItemShape
+                    path, QtCore.Qt.ItemSelectionMode.IntersectsItemShape
                 )
                 self.scene().update(map_rect)
 
@@ -671,7 +671,7 @@ class NodeViewer(QtWidgets.QGraphicsView):
 
     def dropEvent(self, event):
         pos = self.mapToScene(event.pos())
-        event.setDropAction(QtCore.Qt.CopyAction)
+        event.setDropAction(QtCore.Qt.DropAction.CopyAction)
         self.data_dropped.emit(
             event.mimeData(), QtCore.QPoint(pos.x(), pos.y())
         )
@@ -709,12 +709,12 @@ class NodeViewer(QtWidgets.QGraphicsView):
         Args:
             event (QtGui.QKeyEvent): key event.
         """
-        self.ALT_state = event.modifiers() == QtCore.Qt.AltModifier
-        self.CTRL_state = event.modifiers() == QtCore.Qt.ControlModifier
-        self.SHIFT_state = event.modifiers() == QtCore.Qt.ShiftModifier
+        self.ALT_state = event.modifiers() == QtCore.Qt.KeyboardModifier.AltModifier
+        self.CTRL_state = event.modifiers() == QtCore.Qt.KeyboardModifier.ControlModifier
+        self.SHIFT_state = event.modifiers() == QtCore.Qt.KeyboardModifier.ShiftModifier
 
         # Todo: find a better solution to catch modifier keys.
-        if event.modifiers() == (QtCore.Qt.AltModifier | QtCore.Qt.ShiftModifier):
+        if event.modifiers() == (QtCore.Qt.KeyboardModifier.AltModifier | QtCore.Qt.KeyboardModifier.ShiftModifier):
             self.ALT_state = True
             self.SHIFT_state = True
 
@@ -750,9 +750,9 @@ class NodeViewer(QtWidgets.QGraphicsView):
         Args:
             event (QtGui.QKeyEvent): key event.
         """
-        self.ALT_state = event.modifiers() == QtCore.Qt.AltModifier
-        self.CTRL_state = event.modifiers() == QtCore.Qt.ControlModifier
-        self.SHIFT_state = event.modifiers() == QtCore.Qt.ShiftModifier
+        self.ALT_state = event.modifiers() == QtCore.Qt.KeyboardModifier.AltModifier
+        self.CTRL_state = event.modifiers() == QtCore.Qt.KeyboardModifier.ControlModifier
+        self.SHIFT_state = event.modifiers() == QtCore.Qt.KeyboardModifier.ShiftModifier
         super(NodeViewer, self).keyReleaseEvent(event)
 
         # hide and reset cursor text.
@@ -866,7 +866,7 @@ class NodeViewer(QtWidgets.QGraphicsView):
                 self._node_positions[n] = n.xy_pos
 
             # emit selected node id with LMB.
-            if event.button() == QtCore.Qt.LeftButton:
+            if event.button() == QtCore.Qt.MouseButton.LeftButton:
                 self.node_selected.emit(node.id)
 
             if not isinstance(node, BackdropNodeItem):
@@ -905,7 +905,7 @@ class NodeViewer(QtWidgets.QGraphicsView):
             event (QtWidgets.QGraphicsSceneMouseEvent):
                 The event handler from the QtWidgets.QGraphicsScene
         """
-        if event.button() != QtCore.Qt.MiddleButton:
+        if event.button() != QtCore.Qt.MouseButton.MiddleButton:
             self.apply_live_connection(event)
 
     # --- port connections ---
@@ -1638,9 +1638,16 @@ class NodeViewer(QtWidgets.QGraphicsView):
         """
         # use QOpenGLWidget instead of the deprecated QGLWidget to avoid
         # problems with Wayland.
-        import qtpy
-        if Qt.IsPySide2:
-            from PySide2.QtWidgets import QOpenGLWidget
-        elif Qt.IsPyQt5:
-            from PyQt5.QtWidgets import QOpenGLWidget
-        self.setViewport(QOpenGLWidget())
+
+        # TODO: Review this part and make sure we do not break anything
+        # import qtpy
+        # if qtpy.PYSIDE2:
+        #     from PySide2.QtWidgets import QOpenGLWidget
+        # elif qtpy.PYQT5:
+        #     from PyQt5.QtWidgets import QOpenGLWidget
+        # elif qtpy.PYSIDE6:
+        #     from PySide6.QtOpenGLWidgets import QOpenGLWidget
+        # elif qtpy.PYQT6:
+        #     from PyQt6.QtOpenGLWidgets import QOpenGLWidget
+
+        self.setViewport(QtWidgets.QOpenGLWidget())

--- a/NodeGraphQt/widgets/viewer_nav.py
+++ b/NodeGraphQt/widgets/viewer_nav.py
@@ -1,4 +1,4 @@
-from Qt import QtWidgets, QtCore, QtGui
+from qtpy import QtWidgets, QtCore, QtGui
 
 from NodeGraphQt.constants import NodeEnum, ViewerNavEnum
 

--- a/NodeGraphQt/widgets/viewer_nav.py
+++ b/NodeGraphQt/widgets/viewer_nav.py
@@ -99,10 +99,10 @@ class NodeNavigationWidget(QtWidgets.QListView):
 
     def __init__(self, parent=None):
         super(NodeNavigationWidget, self).__init__(parent)
-        self.setSelectionMode(self.SingleSelection)
-        self.setResizeMode(self.Adjust)
-        self.setViewMode(self.ListMode)
-        self.setFlow(self.LeftToRight)
+        self.setSelectionMode(self.SelectionMode.SingleSelection)
+        self.setResizeMode(self.ResizeMode.Adjust)
+        self.setViewMode(self.ViewMode.ListMode)
+        self.setFlow(self.Flow.LeftToRight)
         self.setDragEnabled(False)
         self.setMinimumHeight(20)
         self.setMaximumHeight(36)

--- a/NodeGraphQt/widgets/viewer_nav.py
+++ b/NodeGraphQt/widgets/viewer_nav.py
@@ -27,14 +27,14 @@ class NodeNavigationDelagate(QtWidgets.QStyledItemDelegate):
         )
 
         painter.save()
-        painter.setPen(QtCore.Qt.NoPen)
-        painter.setBrush(QtCore.Qt.NoBrush)
-        painter.setRenderHint(QtGui.QPainter.Antialiasing, True)
+        painter.setPen(QtCore.Qt.PenStyle.NoPen)
+        painter.setBrush(QtCore.Qt.BrushStyle.NoBrush)
+        painter.setRenderHint(QtGui.QPainter.RenderHint.Antialiasing, True)
 
         # background.
         bg_color = QtGui.QColor(*ViewerNavEnum.ITEM_COLOR.value)
         itm_color = QtGui.QColor(80, 128, 123)
-        if option.state & QtWidgets.QStyle.State_Selected:
+        if option.state & QtWidgets.QStyle.StateFlag.State_Selected:
             bg_color = bg_color.lighter(120)
             itm_color = QtGui.QColor(*NodeEnum.SELECTED_BORDER_COLOR.value)
 
@@ -73,7 +73,7 @@ class NodeNavigationDelagate(QtWidgets.QStyledItemDelegate):
             lambda i, j: i - j, (255, 255, 255), bg_color.getRgb()
         )))
         pen = QtGui.QPen(pen_color, 0.5)
-        pen.setCapStyle(QtCore.Qt.RoundCap)
+        pen.setCapStyle(QtCore.Qt.PenCapStyle.RoundCap)
         painter.setPen(pen)
 
         font = painter.font()
@@ -153,7 +153,7 @@ class NodeNavigationWidget(QtWidgets.QListView):
         self.model().appendRow(item)
         self.selectionModel().setCurrentIndex(
             self.model().indexFromItem(item),
-            QtCore.QItemSelectionModel.ClearAndSelect)
+            QtCore.QItemSelectionModel.SelectionFlag.ClearAndSelect)
 
     def update_label_item(self, label, node_id):
         rows = reversed(range(self.model().rowCount()))

--- a/NodeGraphQt/widgets/viewer_nav.py
+++ b/NodeGraphQt/widgets/viewer_nav.py
@@ -149,7 +149,7 @@ class NodeNavigationWidget(QtWidgets.QListView):
         else:
             width = metrics.width(item.text())
         width *= 1.5
-        item.setSizeHint(QtCore.QSize(width, 20))
+        item.setSizeHint(QtCore.QSize(int(width), 20))
         self.model().appendRow(item)
         self.selectionModel().setCurrentIndex(
             self.model().indexFromItem(item),

--- a/dev/convert_qt_wrapper.py
+++ b/dev/convert_qt_wrapper.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+import os
+import logging
+import tempfile
+from typing import Iterator
+
+
+def get_base_dir() -> str:
+    cur_path = os.path.dirname(__file__)
+    base_path = os.path.realpath(os.path.join(cur_path, ".."))
+    return base_path
+
+def replace_in_file(fpath: str, old_str: str, new_str: str) -> None:
+    _tfd, tpath = tempfile.mkstemp()
+    with open(fpath, "r") as fd, os.fdopen(_tfd, "w") as tfd:
+        for fline in fd:
+            tline = fline.replace(old_str, new_str)
+            tfd.write(tline)
+    os.unlink(fpath)
+    os.rename(tpath, fpath)
+
+def get_source_files(root: str) -> Iterator[str]:
+    cpath = os.path.realpath(__file__)
+    for dname, dirs, files in os.walk(root):
+        for fname in files:
+            fpath = os.path.realpath(os.path.join(dname, fname))
+            valid_file = fpath.endswith(".py")
+            valid_file &= fpath != cpath
+            if not valid_file:
+                continue
+            yield fpath
+
+
+if __name__ == "__main__":
+    base_dir = get_base_dir()
+    for src_dir in ["examples", "NodeGraphQt"]:
+        source_dir = os.path.join(base_dir, src_dir)
+        for source_file in get_source_files(source_dir):
+            logging.debug("Processing %s", source_file)
+            replace_in_file(source_file, "from Qt", "from qtpy")
+            replace_in_file(source_file, "import Qt,", "import qtpy,")
+            replace_in_file(source_file, "import Qt\n", "import qtpy\n")

--- a/examples/basic_example.py
+++ b/examples/basic_example.py
@@ -3,7 +3,7 @@
 import os
 import signal
 
-from Qt import QtCore, QtWidgets
+from qtpy import QtCore, QtWidgets
 
 from NodeGraphQt import (
     NodeGraph,

--- a/examples/basic_example.py
+++ b/examples/basic_example.py
@@ -20,7 +20,6 @@ if __name__ == '__main__':
     # handle SIGINT to make the app terminate on CTRL+C
     signal.signal(signal.SIGINT, signal.SIG_DFL)
 
-    QtCore.QCoreApplication.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling)
 
     app = QtWidgets.QApplication([])
 

--- a/examples/nodes/custom_ports_node.py
+++ b/examples/nodes/custom_ports_node.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-from Qt import QtCore, QtGui
+from qtpy import QtCore, QtGui
 
 from NodeGraphQt import BaseNode
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,11 +6,11 @@ license = MIT License
 license_files = LICENSE.md
 long_description = file: README.md
 long_description_content_type = text/markdown
-description = Node graph framework for PySide2/PyQt5 that can be
+description = Node graph framework for PySide2/PyQt5/Pyside6/PyQt6 that can be
               implemented and re-purposed into applications.
 classifiers = Operating System :: OS Independent
               License :: OSI Approved :: MIT License
-              Programming Language :: Python :: 3.6
+              Programming Language :: Python :: 3.8
 url = https://github.com/jchanvfx/NodeGraphQt
 project_urls = 
     Documentation = https://jchanvfx.github.io/NodeGraphQt/api/index.html
@@ -20,12 +20,12 @@ project_urls =
 [options]
 packages = find:
 include_package_data = True
-python_requires = >=3.6
+python_requires = >=3.8
 install_requires =
-    Qt.py>=1.2.0
+    qtpy>=2.3.1
 
 [options.extras_require]
-PySide2 = PySide2>=5.15
+PySide6 = PySide6>=6.5.0
 
 [options.packages.find]
 exclude = examples


### PR DESCRIPTION
I am beginning to work on a Qt6 project that will use this library, so I needed to see how feasible porting to Qt6 would be. Work so far is simply rebasing @jowr's work from PR #327 onto `main` branch, and cleaning up some code added after that PR.

I have done preliminary testing using the example demo with Python 3.12 and QtPy 65.5.0 with both PySide6 v6.6.3.1 and PyQt6 v6.7.0. (Pyside v6.7.0 has some [open bugs](https://bugreports.qt.io/projects/PYSIDE/issues/PYSIDE-2677) with inheritance that prevent the modules from importing properly)