### PR TITLE
fix: #425 ensure accept/reject port type is a set

### DIFF
--- a/NodeGraphQt/base/model.py
+++ b/NodeGraphQt/base/model.py
@@ -543,9 +543,10 @@ class NodeGraphModel(object):
             connection_data = connection_data[key]
 
         if accept_ptype not in connection_data:
-            connection_data[accept_ptype] = [accept_pname]
+            connection_data[accept_ptype] = set([accept_pname])
         else:
-            connection_data[accept_ptype].append(accept_pname)
+            # ensure data remains a set instead of list after json de-serialize
+            connection_data[accept_ptype] = set(connection_data[accept_ptype]) | {accept_pname}
 
     def port_accept_connection_types(self, node_type, port_type, port_name):
         """
@@ -588,9 +589,10 @@ class NodeGraphModel(object):
             connection_data = connection_data[key]
 
         if reject_ptype not in connection_data:
-            connection_data[reject_ptype] = [reject_pname]
+            connection_data[reject_ptype] = set([reject_pname])
         else:
-            connection_data[reject_ptype].append(reject_pname)
+            # ensure data remains a set instead of list after json de-serialize
+            connection_data[reject_ptype] = set(connection_data[reject_ptype]) | {reject_pname}
 
     def port_reject_connection_types(self, node_type, port_type, port_name):
         """


### PR DESCRIPTION
If a session is loaded that has an accept_port_types or reject_port_types field, when the json file is de-serialized, what should be a set internally becomes a list.

This commit ensures that the data in the model is always a set, making conversion each time.