### PR TITLE
Interpret function file path in menu data relative to menu json

### DIFF
--- a/NodeGraphQt/base/graph.py
+++ b/NodeGraphQt/base/graph.py
@@ -775,7 +775,7 @@ class NodeGraph(QtCore.QObject):
         """
         return self._context_menu.get(menu)
 
-    def _deserialize_context_menu(self, menu, menu_data):
+    def _deserialize_context_menu(self, menu, menu_data, anchor_path=None):
         """
         Populate context menu from a dictionary.
 
@@ -783,6 +783,7 @@ class NodeGraph(QtCore.QObject):
             menu (NodeGraphQt.NodeGraphMenu or NodeGraphQt.NodesMenu):
                 parent context menu.
             menu_data (list[dict] or dict): serialized menu data.
+            anchor_path (str or None): directory to interpret file paths relative to (optional)
         """
         if not menu:
             raise ValueError('No context menu named: "{}"'.format(menu))
@@ -791,6 +792,10 @@ class NodeGraph(QtCore.QObject):
         import importlib.util
 
         nodes_menu = self.get_context_menu('nodes')
+
+        anchor = Path(anchor_path).resolve()
+        if anchor.is_file():
+            anchor = anchor.parent
 
         def build_menu_command(menu, data):
             """
@@ -801,14 +806,16 @@ class NodeGraph(QtCore.QObject):
                     menu object.
                 data (dict): serialized menu command data.
             """
-            full_path = os.path.abspath(data['file'])
-            base_dir, file_name = os.path.split(full_path)
-            base_name = os.path.basename(base_dir)
-            file_name, _ = file_name.split('.')
+            func_path = Path(data['file'])
+            if not func_path.is_absolute():
+                func_path = anchor.joinpath(func_path)
+
+            base_name = func_path.parent.name
+            file_name = func_path.stem
 
             mod_name = '{}.{}'.format(base_name, file_name)
 
-            spec = importlib.util.spec_from_file_location(mod_name, full_path)
+            spec = importlib.util.spec_from_file_location(mod_name, func_path)
             mod = importlib.util.module_from_spec(spec)
             sys.modules[mod_name] = mod
             spec.loader.exec_module(mod)
@@ -832,12 +839,12 @@ class NodeGraph(QtCore.QObject):
             elif item_type == 'menu':
                 sub_menu = menu.add_menu(menu_data['label'])
                 items = menu_data.get('items', [])
-                self._deserialize_context_menu(sub_menu, items)
+                self._deserialize_context_menu(sub_menu, items, anchor_path)
         elif isinstance(menu_data, list):
             for item_data in menu_data:
-                self._deserialize_context_menu(menu, item_data)
+                self._deserialize_context_menu(menu, item_data, anchor_path)
 
-    def set_context_menu(self, menu_name, data):
+    def set_context_menu(self, menu_name, data, anchor_path=None):
         """
         Populate a context menu from serialized data.
 
@@ -875,11 +882,12 @@ class NodeGraph(QtCore.QObject):
         Args:
             menu_name (str): name of the parent context menu to populate under.
             data (dict): serialized menu data.
+            anchor_path (str or None): directory to interpret file paths relative to (optional)
         """
         context_menu = self.get_context_menu(menu_name)
-        self._deserialize_context_menu(context_menu, data)
+        self._deserialize_context_menu(context_menu, data, anchor_path)
 
-    def set_context_menu_from_file(self, file_path, menu=None):
+    def set_context_menu_from_file(self, file_path, menu='graph'):
         """
         Populate a context menu from a serialized json file.
 
@@ -892,16 +900,16 @@ class NodeGraph(QtCore.QObject):
             menu (str): name of the parent context menu to populate under.
             file_path (str): serialized menu commands json file.
         """
-        file_path = os.path.abspath(file_path)
+        file = Path(file_path).resolve()
 
         menu = menu or 'graph'
-        if not os.path.isfile(file_path):
-            raise IOError('file doesn\'t exists: "{}"'.format(file_path))
+        if not file.is_file():
+            raise IOError('file doesn\'t exist: "{}"'.format(file))
 
-        with open(file_path) as f:
+        with file.open() as f:
             data = json.load(f)
         context_menu = self.get_context_menu(menu)
-        self._deserialize_context_menu(context_menu, data)
+        self._deserialize_context_menu(context_menu, data, file)
 
     def disable_context_menu(self, disabled=True, name='all'):
         """

--- a/NodeGraphQt/base/graph.py
+++ b/NodeGraphQt/base/graph.py
@@ -4,6 +4,7 @@ import copy
 import json
 import os
 import re
+from pathlib import Path
 
 from Qt import QtCore, QtWidgets
 

--- a/examples/basic_example.py
+++ b/examples/basic_example.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
-import os
 import signal
+from pathlib import Path
 
 from Qt import QtCore, QtWidgets
 
@@ -12,11 +12,12 @@ from NodeGraphQt import (
     NodesPaletteWidget
 )
 
-# import example nodes from the "example_nodes" package
-from nodes import basic_nodes, custom_ports_node, group_node, widget_nodes
+# import example nodes from the "nodes" sub-package
+from examples.nodes import basic_nodes, custom_ports_node, group_node, widget_nodes
 
-if __name__ == '__main__':
+BASE_PATH = Path(__file__).parent.resolve()
 
+def main():
     # handle SIGINT to make the app terminate on CTRL+C
     signal.signal(signal.SIGINT, signal.SIG_DFL)
 
@@ -26,7 +27,8 @@ if __name__ == '__main__':
     graph = NodeGraph()
 
     # set up context menu for the node graph.
-    graph.set_context_menu_from_file('../examples/hotkeys/hotkeys.json')
+    hotkey_path = Path(BASE_PATH, 'hotkeys', 'hotkeys.json')
+    graph.set_context_menu_from_file(hotkey_path, 'graph')
 
     # registered example nodes.
     graph.register_nodes([
@@ -53,9 +55,7 @@ if __name__ == '__main__':
     # create node and set a custom icon.
     n_basic_b = graph.create_node(
         'nodes.basic.BasicNodeB', name='custom icon')
-    n_basic_b.set_icon(
-        os.path.join(os.path.dirname(os.path.abspath(__file__)), 'star.png')
-    )
+    n_basic_b.set_icon(Path(BASE_PATH, 'star.png'))
 
     # create node with the custom port shapes.
     n_custom_ports = graph.create_node(
@@ -140,3 +140,7 @@ if __name__ == '__main__':
     # nodes_palette.show()
 
     app.exec()
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/hotkeys/hotkey_functions.py
+++ b/examples/hotkeys/hotkey_functions.py
@@ -97,7 +97,7 @@ def quit_qt(graph):
     """
     Quit the Qt application.
     """
-    from qtpy import QtCore
+    from Qt import QtCore
     QtCore.QCoreApplication.quit()
 
 def clear_undo(graph):

--- a/examples/hotkeys/hotkey_functions.py
+++ b/examples/hotkeys/hotkey_functions.py
@@ -93,6 +93,12 @@ def clear_session(graph):
     if graph.question_dialog('Clear Current Session?', 'Clear Session'):
         graph.clear_session()
 
+def quit_qt(graph):
+    """
+    Quit the Qt application.
+    """
+    from qtpy import QtCore
+    QtCore.QCoreApplication.quit()
 
 def clear_undo(graph):
     """

--- a/examples/hotkeys/hotkeys.json
+++ b/examples/hotkeys/hotkeys.json
@@ -6,37 +6,44 @@
       {
         "type":"command",
         "label":"Open...",
-        "file":"../examples/hotkeys/hotkey_functions.py",
+        "file":"./hotkey_functions.py",
         "function_name":"open_session",
         "shortcut":"QtGui.QKeySequence.Open"
       },
       {
         "type":"command",
         "label":"Import...",
-        "file":"../examples/hotkeys/hotkey_functions.py",
+        "file":"./hotkey_functions.py",
         "function_name":"import_session",
         "shortcut":""
       },
       {
         "type":"command",
         "label":"Clear Session...",
-        "file":"../examples/hotkeys/hotkey_functions.py",
+        "file":"./hotkey_functions.py",
         "function_name":"clear_session",
         "shortcut":""
       },
       {
         "type":"command",
         "label":"Save...",
-        "file":"../examples/hotkeys/hotkey_functions.py",
+        "file":"./hotkey_functions.py",
         "function_name":"save_session",
         "shortcut":"QtGui.QKeySequence.Save"
       },
       {
         "type":"command",
         "label":"Save As...",
-        "file":"../examples/hotkeys/hotkey_functions.py",
+        "file":"./hotkey_functions.py",
         "function_name":"save_session_as",
         "shortcut":"Ctrl+Shift+S"
+      },
+      {
+        "type":"command",
+        "label":"Exit",
+        "file":"./hotkey_functions.py",
+        "function_name":"quit_qt",
+        "shortcut":"Ctrl+Shift+Q"
       }
     ]
   },
@@ -47,14 +54,14 @@
       {
         "type":"command",
         "label":"Clear Undo History",
-        "file":"../examples/hotkeys/hotkey_functions.py",
+        "file":"./hotkey_functions.py",
         "function_name":"clear_undo",
         "shortcut":""
       },
       {
         "type":"command",
         "label":"Show Undo History",
-        "file":"../examples/hotkeys/hotkey_functions.py",
+        "file":"./hotkey_functions.py",
         "function_name":"show_undo_view",
         "shortcut":""
       },
@@ -64,28 +71,28 @@
       {
         "type":"command",
         "label":"Copy",
-        "file":"../examples/hotkeys/hotkey_functions.py",
+        "file":"./hotkey_functions.py",
         "function_name":"copy_nodes",
         "shortcut":"QtGui.QKeySequence.Copy"
       },
       {
         "type":"command",
         "label":"Cut",
-        "file":"../examples/hotkeys/hotkey_functions.py",
+        "file":"./hotkey_functions.py",
         "function_name":"cut_nodes",
         "shortcut":"QtGui.QKeySequence.Cut"
       },
       {
         "type":"command",
         "label":"Paste",
-        "file":"../examples/hotkeys/hotkey_functions.py",
+        "file":"./hotkey_functions.py",
         "function_name":"paste_nodes",
         "shortcut":"QtGui.QKeySequence.Paste"
       },
       {
         "type":"command",
         "label":"Delete",
-        "file":"../examples/hotkeys/hotkey_functions.py",
+        "file":"./hotkey_functions.py",
         "function_name":"delete_nodes",
         "shortcut":"QtGui.QKeySequence.Delete"
       },
@@ -95,55 +102,55 @@
       {
         "type":"command",
         "label":"Select All",
-        "file":"../examples/hotkeys/hotkey_functions.py",
+        "file":"./hotkey_functions.py",
         "function_name":"select_all_nodes",
         "shortcut":"Ctrl+A"
       },
       {
         "type":"command",
         "label":"Unselect All",
-        "file":"../examples/hotkeys/hotkey_functions.py",
+        "file":"./hotkey_functions.py",
         "function_name":"clear_node_selection",
         "shortcut":"Ctrl+Shift+A"
       },
             {
         "type":"command",
         "label":"Invert Selection",
-        "file":"../examples/hotkeys/hotkey_functions.py",
+        "file":"./hotkey_functions.py",
         "function_name":"invert_node_selection"
       },
       {
         "type":"command",
         "label":"Enable/Disable",
-        "file":"../examples/hotkeys/hotkey_functions.py",
+        "file":"./hotkey_functions.py",
         "function_name":"disable_nodes",
         "shortcut":"D"
       },
       {
         "type":"command",
         "label":"Duplicate",
-        "file":"../examples/hotkeys/hotkey_functions.py",
+        "file":"./hotkey_functions.py",
         "function_name":"duplicate_nodes",
         "shortcut":"Alt+C"
       },
       {
         "type":"command",
         "label":"Extract",
-        "file":"../examples/hotkeys/hotkey_functions.py",
+        "file":"./hotkey_functions.py",
         "function_name":"extract_nodes",
         "shortcut":"Ctrl+Shift+X"
       },
       {
         "type":"command",
         "label":"Clear Connections",
-        "file":"../examples/hotkeys/hotkey_functions.py",
+        "file":"./hotkey_functions.py",
         "function_name":"clear_node_connections",
         "shortcut":"Ctrl+D"
       },
       {
         "type":"command",
         "label":"Fit to Selection",
-        "file":"../examples/hotkeys/hotkey_functions.py",
+        "file":"./hotkey_functions.py",
         "function_name":"fit_to_selection",
         "shortcut":"F"
       },
@@ -153,21 +160,21 @@
       {
         "type":"command",
         "label":"Zoom In",
-        "file":"../examples/hotkeys/hotkey_functions.py",
+        "file":"./hotkey_functions.py",
         "function_name":"zoom_in",
         "shortcut":"="
       },
       {
         "type":"command",
         "label":"Zoom Out",
-        "file":"../examples/hotkeys/hotkey_functions.py",
+        "file":"./hotkey_functions.py",
         "function_name":"zoom_out",
         "shortcut":"-"
       },
       {
         "type":"command",
         "label":"Reset Zoom",
-        "file":"../examples/hotkeys/hotkey_functions.py",
+        "file":"./hotkey_functions.py",
         "function_name":"reset_zoom",
         "shortcut":"H"
       }
@@ -187,21 +194,21 @@
           {
             "type":"command",
             "label":"None",
-            "file":"../examples/hotkeys/hotkey_functions.py",
+            "file":"./hotkey_functions.py",
             "function_name":"bg_grid_none",
             "shortcut":"Alt+1"
           },
           {
             "type":"command",
             "label":"Lines",
-            "file":"../examples/hotkeys/hotkey_functions.py",
+            "file":"./hotkey_functions.py",
             "function_name":"bg_grid_lines",
             "shortcut":"Alt+2"
           },
           {
             "type":"command",
             "label":"Dots",
-            "file":"../examples/hotkeys/hotkey_functions.py",
+            "file":"./hotkey_functions.py",
             "function_name":"bg_grid_dots",
             "shortcut":"Alt+3"
           }
@@ -214,14 +221,14 @@
           {
             "type":"command",
             "label":"Horizontal",
-            "file":"../examples/hotkeys/hotkey_functions.py",
+            "file":"./hotkey_functions.py",
             "function_name":"layout_h_mode",
             "shortcut":"Shift+1"
           },
           {
             "type":"command",
             "label":"Vertical",
-            "file":"../examples/hotkeys/hotkey_functions.py",
+            "file":"./hotkey_functions.py",
             "function_name":"layout_v_mode",
             "shortcut":"Shift+2"
           }
@@ -236,7 +243,7 @@
       {
         "type":"command",
         "label":"Node Search",
-        "file":"../examples/hotkeys/hotkey_functions.py",
+        "file":"./hotkey_functions.py",
         "function_name":"toggle_node_search",
         "shortcut":"Tab"
       },
@@ -246,14 +253,14 @@
       {
         "type":"command",
         "label":"Auto Layout Up Stream",
-        "file":"../examples/hotkeys/hotkey_functions.py",
+        "file":"./hotkey_functions.py",
         "function_name":"layout_graph_up",
         "shortcut":"L"
       },
       {
         "type":"command",
         "label":"Auto Layout Down Stream",
-        "file":"../examples/hotkeys/hotkey_functions.py",
+        "file":"./hotkey_functions.py",
         "function_name":"layout_graph_down",
         "shortcut":"Ctrl+L"
       },
@@ -263,7 +270,7 @@
       {
         "type":"command",
         "label":"Expand Group Node",
-        "file":"../examples/hotkeys/hotkey_functions.py",
+        "file":"./hotkey_functions.py",
         "function_name":"expand_group_node",
         "shortcut":"Alt+Enter"
       }
@@ -276,21 +283,21 @@
       {
         "type":"command",
         "label":"Curved",
-        "file":"../examples/hotkeys/hotkey_functions.py",
+        "file":"./hotkey_functions.py",
         "function_name":"curved_pipe",
         "shortcut":"Ctrl+1"
       },
       {
         "type":"command",
         "label":"Straight",
-        "file":"../examples/hotkeys/hotkey_functions.py",
+        "file":"./hotkey_functions.py",
         "function_name":"straight_pipe",
         "shortcut":"Ctrl+2"
       },
       {
         "type":"command",
         "label":"Angle",
-        "file":"../examples/hotkeys/hotkey_functions.py",
+        "file":"./hotkey_functions.py",
         "function_name":"angle_pipe",
         "shortcut":"Ctrl+3"
       }


### PR DESCRIPTION
Previously, it was tricky for application code to use the declarative json menu feature,
because the file paths (`'file'` key) were relative to the cwd of the Python interpreter. 

With this change, application code can construct an absolute path to the shortcut 
menu json definition at runtime (using importlib.resources or relative to __file__, etc)
while the dynamically loaded python module path is assumed relative to the json path.

If an absolute filepath is given in the menu data dict, that is used instead.

I updated the basic_example to use this feature, and as a side effect, it is much more robust and easy to execute.
Now, the user does not have to `cd examples/` in order to run the file. The example no long relies on the cwd to resolve file names. Even `python -m examples.basic_example` works. 

I used the `pathlib.Path` module throughout my code. This is the modern and prefered method of dealing with cross-platform paths since Python 3.4. But I understand most of the codebase is still using os.path. My implementation can change, or I can help migrate to the "new" `Path()` module throughout NodeGraphQt.

Edit: I also added a Exit item to the example menu
Edit 2: Oops, looks like I guessed the wrong number for branch name. Can't change that easily now.