### PR TITLE
Fix AttributeError for API change on QWheelEvent from Qt5

### DIFF
--- a/NodeGraphQt/widgets/viewer.py
+++ b/NodeGraphQt/widgets/viewer.py
@@ -669,7 +669,11 @@ class NodeViewer(QtWidgets.QGraphicsView):
             delta = event.angleDelta().y()
             if delta == 0:
                 delta = event.angleDelta().x()
-        self._set_viewer_zoom(delta, pos=event.pos())
+        try:
+            self._set_viewer_zoom(delta, pos=event.pos())
+        except AttributeError:
+            # For PyQt5 and above
+            self._set_viewer_zoom(delta, pos=event.position().toPoint())
 
     def dropEvent(self, event):
         pos = self.mapToScene(event.pos())


### PR DESCRIPTION
This quick fix is to prevent the AttributeError from the API changes. 