### PR TITLE
Fixed another quick API change of Qt6 on mouse selection rectangle

### DIFF
--- a/NodeGraphQt/widgets/viewer.py
+++ b/NodeGraphQt/widgets/viewer.py
@@ -617,9 +617,7 @@ class NodeViewer(QtWidgets.QGraphicsView):
                 path = QtGui.QPainterPath()
                 path.addRect(map_rect)
                 self._rubber_band.setGeometry(rect)
-                self.scene().setSelectionArea(
-                    path, QtCore.Qt.IntersectsItemShape
-                )
+                self.scene().setSelectionArea(path)
                 self.scene().update(map_rect)
 
                 if self.SHIFT_state or self.CTRL_state:


### PR DESCRIPTION
This merge contains your latest changes and fixes another tiny API change on Qt6 on mouse selection rectangle.
I've just removed the faulty argument type that changed on Qt6 and delegated to default behaviour on selection rectangle which I think it was your intented one so nothing changes normally. 