### PR TITLE
Adds missing set_name function

### DIFF
--- a/NodeGraphQt/custom_widgets/properties_bin/custom_widget_value_edit.py
+++ b/NodeGraphQt/custom_widgets/properties_bin/custom_widget_value_edit.py
@@ -140,6 +140,9 @@ class _NumberValueEdit(QtWidgets.QLineEdit):
         elif event.key() == QtCore.Qt.Key_Down:
             return
 
+    def set_name(self, name):
+        self._name = name
+
     # private
 
     def _reset_previous_x(self):


### PR DESCRIPTION
Adding this fixes a fatal error which prevents the properties bin from displaying properly when a number node is used.