### PR TITLE
fixes the limit box for the prop_list

### DIFF
--- a/NodeGraphQt/custom_widgets/properties_bin/node_property_widgets.py
+++ b/NodeGraphQt/custom_widgets/properties_bin/node_property_widgets.py
@@ -798,13 +798,15 @@ class PropertiesBinWidget(QtWidgets.QWidget):
         if self.limit() == 0 or self._lock:
             return
 
-        rows = self._prop_list.rowCount() - 1
-        if rows >= self.limit():
-            self._prop_list.removeRow(rows - 1)
-
+        # remove pre-existing instance
         itm_find = self._prop_list.findItems(node.id, QtCore.Qt.MatchExactly)
         if itm_find:
             self._prop_list.removeRow(itm_find[0].row())
+
+        rows = self._prop_list.rowCount() - 1
+        if rows >= (self.limit()-1):
+            # remove last row
+            self._prop_list.removeRow(rows - 1)
 
         self._prop_list.insertRow(0)
 


### PR DESCRIPTION
Currently the property window is having one more item then the limit, as the limitation is done based on 
the amount of properties before the insertion. 

The limitation doesn't take into account if a widget is already in the list an might remove other properties that won't interfer with the limit.

This PR fixes post issues described above by reordering the operations and taking the newly added item into account. 