### PR TITLE
Node Icon Max Width

### DIFF
--- a/NodeGraphQt/qgraphics/node_base.py
+++ b/NodeGraphQt/qgraphics/node_base.py
@@ -804,6 +804,11 @@ class NodeItem(AbstractNodeItem):
                 NodeEnum.ICON_SIZE.value,
                 QtCore.Qt.SmoothTransformation
             )
+        if pixmap.size().width() > NodeEnum.ICON_SIZE.value:
+            pixmap = pixmap.scaledToWidth(
+                NodeEnum.ICON_SIZE.value,
+                QtCore.Qt.SmoothTransformation
+            )
         self._icon_item.setPixmap(pixmap)
         if self.scene():
             self.post_init()


### PR DESCRIPTION
This fix makes sure that the icon widht is also not bigger then the ICON_SIZE.value  

Previously:
<img width="1101" height="829" alt="grafik" src="https://github.com/user-attachments/assets/c33ac836-32f2-4151-9235-711d63fd164b" />

Now:
<img width="1100" height="831" alt="grafik" src="https://github.com/user-attachments/assets/cfa527b8-b33e-4a07-8cf2-eefe5c23dfd1" />

