### PR TITLE
Fixes copy and pasting nodes with accept_connection_types and/or reject_connection_types.

### DIFF
--- a/NodeGraphQt/base/graph.py
+++ b/NodeGraphQt/base/graph.py
@@ -1722,12 +1722,8 @@ class NodeGraph(QtCore.QObject):
         serial_data['graph']['pipe_style'] = self.pipe_style()
 
         # connection constrains.
-        serial_data['graph']['accept_connection_types'] = {
-            k: list(v) for k, v in self.model.accept_connection_types.items()
-        }
-        serial_data['graph']['reject_connection_types'] = {
-            k: list(v) for k, v in self.model.reject_connection_types.items()
-        }
+        serial_data['graph']['accept_connection_types'] = json.dumps(self.model.accept_connection_types, default=list)
+        serial_data['graph']['reject_connection_types'] = json.dumps(self.model.reject_connection_types, default=list)
 
         # serialize nodes.
         for n in nodes:
@@ -1784,6 +1780,15 @@ class NodeGraph(QtCore.QObject):
             list[NodeGraphQt.Nodes]: list of node instances.
         """
         # update node graph properties.
+        
+        # Recursive function to convert last lists to sets
+        def convert_last_list_to_set(d):
+            for key, value in d.items():
+                if isinstance(value, dict):
+                    convert_last_list_to_set(value)
+                elif isinstance(value, list):
+                    d[key] = set(value)  # convert list to set
+
         for attr_name, attr_value in data.get("graph", {}).items():
             if adjust_graph_style:
                 if attr_name == "layout_direction":
@@ -1798,14 +1803,15 @@ class NodeGraph(QtCore.QObject):
                     self.set_pipe_style(attr_value)
 
             # connection constrains.
-            elif attr_name == 'accept_connection_types':
-                self.model.accept_connection_types = {
-                    k: set(v) for k, v in attr_value.items()
-                }
+            if attr_name == 'accept_connection_types':
+                attr_value = json.loads(attr_value)
+                convert_last_list_to_set(attr_value)
+                self.model.accept_connection_types = attr_value
+
             elif attr_name == 'reject_connection_types':
-                self.model.reject_connection_types = {
-                    k: set(v) for k, v in attr_value.items()
-                }
+                attr_value = json.loads(attr_value)
+                convert_last_list_to_set(attr_value)
+                self.model.reject_connection_types =  attr_value
 
         # build the nodes.
         nodes = {}


### PR DESCRIPTION
The issue is the serialization and deserialization of nodes that have accept_connection_types and/or reject_connection_types.
This is a 4 times nested dict: 
<img width="1421" height="631" alt="Screenshot 2025-09-01 024332" src="https://github.com/user-attachments/assets/fee928f9-a83f-49f9-9f51-b3e05f84c70e" />

The current implementation is only taking the first two levels into account during the serializing and deserializing phase.

Closes #464