### PR TITLE
Fixes to basic_example.py

### DIFF
--- a/examples/basic_example.py
+++ b/examples/basic_example.py
@@ -66,7 +66,7 @@ def main():
     # create node and set a custom icon.
     n_basic_b = graph.create_node(
         'nodes.basic.BasicNodeB', name='custom icon')
-    n_basic_b.set_icon(Path(BASE_PATH, 'img', 'star.png'))
+    n_basic_b.set_icon(str(Path(BASE_PATH, 'img', 'star.png')))
 
     # create node with the custom port shapes.
     n_custom_ports = graph.create_node(
@@ -168,7 +168,7 @@ def main():
     nodes_palette.set_category_label('nodes.group', 'Group Nodes')
     # nodes_palette.show()
 
-    app.exec()
+    app.exec_()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I'm looking to get started using NodeGraphQt for a project, and had a little difficulty getting started running the basic example.

First off, my virtual environment looks like this:

```
$ pip3 list
Package       Version
------------- ----------
NodeGraphQt   0.6.43
pip           22.0.2
PySide2       5.15.2.1
Qt.py         1.4.8
setuptools    59.6.0
shiboken2     5.15.2.1
types-pyside2 5.15.2.1.7
```

With the above dependencies, I required the changes in this pull request to get basic_example.py to work correctly.
With your input, I'd love to add a 'getting started' section to the readme.md which calls out the dependencies and guides the developer through setting up a virtual environment.

Thanks

