### PR TITLE
Fix documentation for register_node pos

### DIFF
--- a/NodeGraphQt/base/graph.py
+++ b/NodeGraphQt/base/graph.py
@@ -431,7 +431,7 @@ class NodeGraph(QtCore.QObject):
         called when a pipe connection has been changed in the viewer.
 
         Args:
-            disconnected (list[list[widgets.port.PortItem]):
+            disconnected (list[list[widgets.port.PortItem]]):
                 pair list of port view items.
             connected (list[list[widgets.port.PortItem]]):
                 pair list of port view items.

--- a/NodeGraphQt/base/graph.py
+++ b/NodeGraphQt/base/graph.py
@@ -357,7 +357,7 @@ class NodeGraph(QtCore.QObject):
                 node_ids = sorted(re.findall(r'node:([\w\.]+)', search_str))
                 x, y = pos.x(), pos.y()
                 for node_id in node_ids:
-                    self.create_node(node_id, pos=[x, y])
+                    self.create_node(node_id, pos=(x, y))
                     x += 80
                     y += 80
         elif mimedata.hasFormat('text/uri-list'):
@@ -422,7 +422,7 @@ class NodeGraph(QtCore.QObject):
 
         Args:
             node_type (str): node identifier.
-            pos (tuple or list): x, y position for the node.
+            pos (tuple[int, int]): x, y position for the node.
         """
         self.create_node(node_type, pos=pos)
 
@@ -1200,7 +1200,7 @@ class NodeGraph(QtCore.QObject):
             selected (bool): set created node to be selected.
             color (tuple or str): node color ``(255, 255, 255)`` or ``"#FFFFFF"``.
             text_color (tuple or str): text color ``(255, 255, 255)`` or ``"#FFFFFF"``.
-            pos (list[int, int]): initial x, y position for the node (default: ``(0, 0)``).
+            pos (tuple[int, int]): initial x, y position for the node (default: ``(0, 0)``).
             push_undo (bool): register the command to the undo stack. (default: True)
 
         Returns:

--- a/docs/examples/ex_menu.rst
+++ b/docs/examples/ex_menu.rst
@@ -100,7 +100,7 @@ can override context menus on a per node type basis.
 
     # create some nodes.
     foo_node = graph.create_node('io.github.jchanvfx.FooNode')
-    bar_node = graph.create_node('io.github.jchanvfx', pos=[300, 100])
+    bar_node = graph.create_node('io.github.jchanvfx', pos=(300, 100))
 
     # show widget.
     node_graph.widget.show()

--- a/docs/examples/ex_node.rst
+++ b/docs/examples/ex_node.rst
@@ -35,7 +35,7 @@ Creating Nodes
 
         # here we create a couple nodes in the node graph.
         node_a = node_graph.create_node('io.github.jchanvfx.MyNode', name='node a')
-        node_b = node_graph.create_node('io.github.jchanvfx.MyNode', name='node b', pos=[300, 100])
+        node_b = node_graph.create_node('io.github.jchanvfx.MyNode', name='node b', pos=(300, 100))
 
         app.exec_()
 


### PR DESCRIPTION
The docs currently describe the pos argument as list[int, int], but the method actually expects a tuple (int, int).
The basic example from here (https://chantonic.com/NodeGraphQt/api/examples/ex_overview.html) also uses tuple.
Note: if lists were intended, the correct type would be list[int], not list[int, int].