### PR TITLE
Use the node's serialize code when serializing graph.

### DIFF
--- a/NodeGraphQt/base/graph.py
+++ b/NodeGraphQt/base/graph.py
@@ -1754,7 +1754,7 @@ class NodeGraph(QtCore.QObject):
             # update the node model.
             n.update_model()
 
-            node_dict = n.model.to_dict
+            node_dict = n.serialize()
             nodes_data.update(node_dict)
 
         for n_id, n_data in nodes_data.items():


### PR DESCRIPTION
Hello! Wonderful project here! I'm using it for a school project, trying to port my [Blender addon](https://nodes.tools) to a UI that works in Maya.

In order for my system to work I have to add some custom information to graphs and nodes, and in order to keep it around I have to override the serialize/deserialize code for both nodes and graphs. Unfortunately, the graph's serialize code doesn't use the node's serialize method. I don't know if there is a really good reason for this that I am missing.

Anyhow the purpose of this very small change is to make it easier for devs to modify NodeGraphQt to use their own custom data.

Thanks! And thank you for the project. Without it I would have had to come up with another idea for a project...