### PR TITLE
Fixes to be able to run basic example with Python 3.13.5 on Debian 13

### DIFF
--- a/NodeGraphQt/base/menu.py
+++ b/NodeGraphQt/base/menu.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 import re
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 from Qt import QtGui, QtCore
 
@@ -141,7 +141,7 @@ class NodeGraphMenu(object):
         """
         action = GraphAction(name, self._graph.viewer())
         action.graph = self._graph
-        if LooseVersion(QtCore.qVersion()) >= LooseVersion('5.10'):
+        if Version(QtCore.qVersion()) >= Version("5.10"):
             action.setShortcutVisibleInContextMenu(True)
 
         if shortcut:
@@ -218,7 +218,7 @@ class NodesMenu(NodeGraphMenu):
 
         action = NodeAction(name, self._graph.viewer())
         action.graph = self._graph
-        if LooseVersion(QtCore.qVersion()) >= LooseVersion('5.10'):
+        if Version(QtCore.qVersion()) >= Version("5.10"):
             action.setShortcutVisibleInContextMenu(True)
 
         if shortcut:

--- a/NodeGraphQt/widgets/viewer.py
+++ b/NodeGraphQt/widgets/viewer.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 import math
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 from Qt import QtGui, QtCore, QtWidgets
 
@@ -201,7 +201,7 @@ class NodeViewer(QtWidgets.QGraphicsView):
         if self._undo_action and self._redo_action:
             self._undo_action.setShortcuts(QtGui.QKeySequence.Undo)
             self._redo_action.setShortcuts(QtGui.QKeySequence.Redo)
-            if LooseVersion(QtCore.qVersion()) >= LooseVersion('5.10'):
+            if Version(QtCore.qVersion()) >= Version("5.10"):
                 self._undo_action.setShortcutVisibleInContextMenu(True)
                 self._redo_action.setShortcutVisibleInContextMenu(True)
 

--- a/NodeGraphQt/widgets/viewer_nav.py
+++ b/NodeGraphQt/widgets/viewer_nav.py
@@ -149,7 +149,7 @@ class NodeNavigationWidget(QtWidgets.QListView):
         else:
             width = metrics.width(item.text())
         width *= 1.5
-        item.setSizeHint(QtCore.QSize(width, 20))
+        item.setSizeHint(QtCore.QSize(int(width), 20))
         self.model().appendRow(item)
         self.selectionModel().setCurrentIndex(
             self.model().indexFromItem(item),


### PR DESCRIPTION
These are fixes I had to apply to get the basic example script to run with Python 3.13.5 in Debian 13. Below is my `pip list`.
```
Package       Version  Editable project location
------------- -------- ----------------------------------------
NodeGraphQt   0.6.44   /home/jwright/repos/jmwright/NodeGraphQt
packaging     26.0
pip           25.1.1
PyQt5         5.15.11
PyQt5-Qt5     5.15.18
PyQt5_sip     12.18.0
Qt.py         2.0.3
types-PySide6 6.10.1.1
```