### PR TITLE
Fix SubGraph deserialize crash when parent port nodes are missing

### DIFF
--- a/NodeGraphQt/base/graph.py
+++ b/NodeGraphQt/base/graph.py
@@ -2712,11 +2712,33 @@ class SubGraph(NodeGraph):
             identifier = n_data['type_']
             name = n_data.get('name')
             if identifier == PortInputNode.type_:
-                nodes[n_id] = input_nodes[name]
+                input_node = input_nodes.get(name)
+                if input_node is None:
+                    parent_port = self.node.get_input(name)
+                    if parent_port is None:
+                        parent_port = self.node.add_input(name)
+                    input_node = PortInputNode(parent_port=parent_port)
+                    input_node.NODE_NAME = name
+                    input_node.model.set_property('name', name)
+                    input_node.add_output(name)
+                    input_nodes[name] = input_node
+                    self.add_node(input_node, selected=False, push_undo=False)
+                nodes[n_id] = input_node
                 nodes[n_id].set_pos(*(n_data.get('pos') or [0, 0]))
                 continue
             elif identifier == PortOutputNode.type_:
-                nodes[n_id] = output_nodes[name]
+                output_node = output_nodes.get(name)
+                if output_node is None:
+                    parent_port = self.node.get_output(name)
+                    if parent_port is None:
+                        parent_port = self.node.add_output(name)
+                    output_node = PortOutputNode(parent_port=parent_port)
+                    output_node.NODE_NAME = name
+                    output_node.model.set_property('name', name)
+                    output_node.add_input(name)
+                    output_nodes[name] = output_node
+                    self.add_node(output_node, selected=False, push_undo=False)
+                nodes[n_id] = output_node
                 nodes[n_id].set_pos(*(n_data.get('pos') or [0, 0]))
                 continue
 


### PR DESCRIPTION
## Summary
Fixes a crash in nested group navigation where `SubGraph._deserialize()` raises `KeyError` (for example `'in'`) when serialized `PortInputNode` / `PortOutputNode` names are not present in rebuilt `input_nodes` / `output_nodes`.

## Reproduction
1. Create/open a graph with nested groups:
- Root graph -> `Group A`
- Inside `Group A` -> `Group B`
2. Ensure each group has default ports (`in` / `out`) and internal connections.
3. Double-click into `Group A`, then into `Group B`.
4. Navigate back up using breadcrumb (for example from `Group B` to `Group A`/root).
5. Re-open nested group through breadcrumb navigation.

### Actual
`SubGraph._deserialize()` can crash with:
`KeyError: 'in'` (or another port name) when mapping serialized port nodes.

### Expected
Nested breadcrumb navigation should deserialize and reopen subgraphs without exceptions.

## Root Cause
`_deserialize()` assumed all serialized port-node names already exist and used direct indexing:
- `input_nodes[name]`
- `output_nodes[name]`

In nested expand/collapse/breadcrumb flows, this assumption can fail.

## Fix
In `NodeGraphQt/base/graph.py`:
- Replace direct indexing with safe lookups (`.get(name)`).
- If missing:
  - create missing parent group port (`self.node.add_input(name)` / `self.node.add_output(name)`),
  - create corresponding `PortInputNode` / `PortOutputNode`,
  - add node to graph and continue deserialization.

## Result
Deserialization recovers gracefully instead of crashing, and nested group breadcrumb navigation no longer throws `KeyError`.

## Verification
- Reproduced the crash before the change.
- Re-tested nested breadcrumb navigation after the change; no `KeyError` is raised.
- Confirmed missing port-node mappings are recovered during deserialization.
